### PR TITLE
Load reference.conf from disk

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -300,7 +300,5 @@ The following is the default configuration as shipped with sharry for
 reference.
 
 ```
-sharry {
 {{& default-configuration}}
-}
 ```


### PR DESCRIPTION
Instead of doing `ConfigFactory.defaultReference()`, because this
injects system properties that shouldn't make it into the manual.

Refs: #21