### PR TITLE
Update publish-until if validity is changed

### DIFF
--- a/modules/backend/src/main/scala/sharry/backend/share/Queries.scala
+++ b/modules/backend/src/main/scala/sharry/backend/share/Queries.scala
@@ -427,14 +427,18 @@ object Queries {
       .run
 
   def setValidity(share: Ident, value: Duration): ConnectionIO[Int] =
-    Sql
-      .updateRow(
-        RShare.table,
-        RShare.Columns.id.is(share),
-        RShare.Columns.validity.setTo(value)
-      )
-      .update
-      .run
+    for {
+      n <-
+        Sql
+          .updateRow(
+            RShare.table,
+            RShare.Columns.id.is(share),
+            RShare.Columns.validity.setTo(value)
+          )
+          .update
+          .run
+      k <- RPublishShare.updateValidityTime(share, value)
+    } yield n + k
 
   def setMaxViews(share: Ident, value: Int): ConnectionIO[Int] =
     Sql


### PR DESCRIPTION
For published shares, the publish-until date is updated with respect
to the changed validity time. It is not done for un-published shares,
since the user has still to click the publish button anyways.

Fixes #167 