### PR TITLE
Don't loose text when switching editor modes

### DIFF
--- a/modules/webapp/src/main/elm/Page/Detail/Update.elm
+++ b/modules/webapp/src/main/elm/Page/Detail/Update.elm
@@ -217,11 +217,8 @@ update flags msg model =
 
         DescEditMsg lmsg ->
             case model.descEdit of
-                Just ( dm, _ ) ->
+                Just ( dm, txt ) ->
                     let
-                        txt =
-                            Maybe.withDefault "" model.share.descriptionRaw
-
                         ( m, str ) =
                             Comp.MarkdownInput.update txt lmsg dm
                     in


### PR DESCRIPTION
When switching between modes (for edit description) the text was lost,
because it re-initialized the field with the original share data.

Fixes: #195