### PR TITLE
Doc: Add missing $connection_upgrade variable in http block

### DIFF
--- a/modules/microsite/docs/doc/reverseproxy.md
+++ b/modules/microsite/docs/doc/reverseproxy.md
@@ -103,39 +103,46 @@ timeouts.
 
 
 ```
-server {
-    listen 0.0.0.0:80 ;
-    listen [::]:80 ;
-    server_name subdomain.otherdomain.tld ;
-    location /.well-known/acme-challenge {
-        root /var/data/nginx/ACME-PUBLIC;
-        auth_basic off;
+http {
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
     }
-    location / {
-        return 301 https://$host$request_uri;
+
+    server {
+        listen 0.0.0.0:80 ;
+        listen [::]:80 ;
+        server_name subdomain.otherdomain.tld ;
+        location /.well-known/acme-challenge {
+            root /var/data/nginx/ACME-PUBLIC;
+            auth_basic off;
+        }
+        location / {
+            return 301 https://$host$request_uri;
+        }
     }
-}
-server {
-    listen 0.0.0.0:443 ssl http2 ;
-    listen [::]:443 ssl http2 ;
-    server_name sharry.example.com ;
-    location /.well-known/acme-challenge {
-        root /var/data/nginx/ACME-PUBLIC;
-        auth_basic off;
-    }
-    ssl_certificate /var/lib/acme/sharry.example.com/fullchain.pem;
-    ssl_certificate_key /var/lib/acme/sharry.example.com/key.pem;
-    ssl_trusted_certificate /var/lib/acme/sharry.example.com/full.pem;
-    location / {
-        proxy_pass http://192.168.1.11:9090;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
-        proxy_buffering off;
-        client_max_body_size 105M;
-        proxy_send_timeout   300s;
-        proxy_read_timeout   300s;
-        send_timeout         300s;
+    server {
+        listen 0.0.0.0:443 ssl http2 ;
+        listen [::]:443 ssl http2 ;
+        server_name sharry.example.com ;
+        location /.well-known/acme-challenge {
+            root /var/data/nginx/ACME-PUBLIC;
+            auth_basic off;
+        }
+        ssl_certificate /var/lib/acme/sharry.example.com/fullchain.pem;
+        ssl_certificate_key /var/lib/acme/sharry.example.com/key.pem;
+        ssl_trusted_certificate /var/lib/acme/sharry.example.com/full.pem;
+        location / {
+            proxy_pass http://192.168.1.11:9090;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_buffering off;
+            client_max_body_size 105M;
+            proxy_send_timeout   300s;
+            proxy_read_timeout   300s;
+            send_timeout         300s;
+        }
     }
 }
 ```


### PR DESCRIPTION
`$connection_upgrade` variable doesn't exist by default, and needs to be created with a `map $http_upgrade $connection_upgrade` block.
Ref: point 6 in [NGINX WebSocket Example](https://www.nginx.com/blog/websocket-nginx/)