### PR TITLE
Use a dynamic base-url if the base-url setting is unchanged

### DIFF
--- a/modules/common/src/main/scala/sharry/common/LenientUri.scala
+++ b/modules/common/src/main/scala/sharry/common/LenientUri.scala
@@ -78,6 +78,9 @@ case class LenientUri(
       }
     )
 
+  def isLocal: Boolean =
+    host.exists(_.equalsIgnoreCase("localhost"))
+
   def asString: String = {
     val schemePart = scheme.toList.mkString(":")
     val authPart   = authority.map(a => s"//$a").getOrElse("")

--- a/modules/restapi/src/main/resources/sharry-openapi.yml
+++ b/modules/restapi/src/main/resources/sharry-openapi.yml
@@ -1680,7 +1680,6 @@ components:
           type: string
         baseUrl:
           type: string
-          format: uri
         logoUrl:
           type: string
         iconUrl:

--- a/modules/restserver/src/main/scala/sharry/restserver/CookieData.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/CookieData.scala
@@ -3,20 +3,19 @@ package sharry.restserver
 import org.http4s._
 import org.http4s.util._
 import sharry.backend.auth._
-import sharry.common.AccountId
+import sharry.common._
 
 case class CookieData(auth: AuthToken) {
   def accountId: AccountId = auth.account
   def asString: String     = auth.asString
 
-  def asCookie(cfg: Config): ResponseCookie = {
-    val domain = cfg.baseUrl.host
-    val sec    = cfg.baseUrl.scheme.exists(_.endsWith("s"))
-    val path   = cfg.baseUrl.path / "api" / "v2"
+  def asCookie(baseUrl: LenientUri): ResponseCookie = {
+    val sec  = baseUrl.scheme.exists(_.endsWith("s"))
+    val path = baseUrl.path / "api" / "v2"
     ResponseCookie(
       CookieData.cookieName,
       asString,
-      domain = domain,
+      domain = None,
       path = Some(path.asString),
       httpOnly = true,
       secure = sec
@@ -45,14 +44,14 @@ object CookieData {
       .map(_.value)
       .toRight("Couldn't find an authenticator")
 
-  def deleteCookie(cfg: Config): ResponseCookie =
+  def deleteCookie(baseUrl: LenientUri): ResponseCookie =
     ResponseCookie(
       cookieName,
       "",
-      domain = cfg.baseUrl.host,
-      path = Some(cfg.baseUrl.path / "api" / "v2").map(_.asString),
+      domain = None,
+      path = Some(baseUrl.path / "api" / "v2").map(_.asString),
       httpOnly = true,
-      secure = cfg.baseUrl.scheme.exists(_.endsWith("s")),
+      secure = baseUrl.scheme.exists(_.endsWith("s")),
       maxAge = Some(-1)
     )
 }

--- a/modules/restserver/src/main/scala/sharry/restserver/RestServer.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/RestServer.scala
@@ -21,6 +21,7 @@ import sharry.common.syntax.all._
 import sharry.backend.auth.AuthToken
 import sharry.restserver.routes._
 import sharry.restserver.webapp._
+import sharry.common.LenientUri
 
 object RestServer {
   private[this] val logger = getLogger
@@ -89,7 +90,7 @@ object RestServer {
         restApp.backend,
         token,
         cfg,
-        cfg.baseUrl / "api" / "v2" / "alias" / "upload"
+        LenientUri.EmptyPath / "api" / "v2" / "alias" / "upload"
       ),
       "mail" -> NotifyRoutes(restApp.backend, token, cfg)
     )
@@ -108,7 +109,7 @@ object RestServer {
         restApp.backend,
         token,
         cfg,
-        cfg.baseUrl / "api" / "v2" / "sec" / "upload"
+        LenientUri.EmptyPath / "api" / "v2" / "sec" / "upload"
       ),
       "mail" -> MailRoutes(restApp.backend, token, cfg)
     )

--- a/modules/restserver/src/main/scala/sharry/restserver/http4s/ClientRequestInfo.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/http4s/ClientRequestInfo.scala
@@ -1,0 +1,68 @@
+package sharry.restserver.http4s
+
+import cats.data.NonEmptyList
+import cats.implicits._
+
+import sharry.common._
+import sharry.restserver.Config
+
+import org.http4s._
+import org.http4s.headers._
+import org.http4s.util.CaseInsensitiveString
+
+/** Obtain information about the client by inspecting the request.
+  */
+object ClientRequestInfo {
+
+  def getBaseUrl[F[_]](cfg: Config, req: Request[F]): LenientUri =
+    if (cfg.baseUrl.isLocal) getBaseUrl(req, cfg.bind.port).getOrElse(cfg.baseUrl)
+    else cfg.baseUrl
+
+  private def getBaseUrl[F[_]](req: Request[F], serverPort: Int): Option[LenientUri] =
+    for {
+      scheme <- NonEmptyList.fromList(getProtocol(req).toList)
+      host   <- getHostname(req)
+      port     = xForwardedPort(req).getOrElse(serverPort)
+      hostPort = if (port == 80 || port == 443) host else s"${host}:${port}"
+    } yield LenientUri(scheme, Some(hostPort), LenientUri.EmptyPath, None, None)
+
+  def getHostname[F[_]](req: Request[F]): Option[String] =
+    xForwardedHost(req)
+      .orElse(xForwardedFor(req))
+      .orElse(host(req))
+
+  def getProtocol[F[_]](req: Request[F]): Option[String] =
+    xForwardedProto(req).orElse(clientConnectionProto(req))
+
+  private def host[F[_]](req: Request[F]): Option[String] =
+    req.headers.get(Host).map(_.host)
+
+  private def xForwardedFor[F[_]](req: Request[F]): Option[String] =
+    req.headers
+      .get(`X-Forwarded-For`)
+      .flatMap(_.values.head)
+      .flatMap(inet => Option(inet.getHostName).orElse(Option(inet.getHostAddress)))
+
+  private def xForwardedHost[F[_]](req: Request[F]): Option[String] =
+    req.headers
+      .get(CaseInsensitiveString("X-Forwarded-Host"))
+      .map(_.value)
+
+  private def xForwardedProto[F[_]](req: Request[F]): Option[String] =
+    req.headers
+      .get(CaseInsensitiveString("X-Forwarded-Proto"))
+      .map(_.value)
+
+  private def clientConnectionProto[F[_]](req: Request[F]): Option[String] =
+    req.isSecure.map {
+      case true  => "https"
+      case false => "http"
+    }
+
+  private def xForwardedPort[F[_]](req: Request[F]): Option[Int] =
+    req.headers
+      .get(CaseInsensitiveString("X-Forwarded-Port"))
+      .map(_.value)
+      .flatMap(str => Either.catchNonFatal(str.toInt).toOption)
+
+}

--- a/modules/restserver/src/main/scala/sharry/restserver/routes/InfoRoutes.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/routes/InfoRoutes.scala
@@ -29,6 +29,10 @@ object InfoRoutes {
     }
   }
 
+  private def getBaseUrl(cfg: Config): String =
+    if (cfg.baseUrl.isLocal) cfg.baseUrl.path.asString
+    else cfg.baseUrl.asString
+
   def appConfig(cfg: Config): AppConfig = {
     val assetPath = s"/app/assets/sharry-webapp/${BuildInfo.version}"
     val logoUrl =
@@ -39,7 +43,7 @@ object InfoRoutes {
       else s"$assetPath/img/icon.svg"
     AppConfig(
       cfg.webapp.appName,
-      cfg.baseUrl,
+      getBaseUrl(cfg),
       logoUrl,
       iconUrl,
       cfg.webapp.appFooter,

--- a/modules/restserver/src/main/scala/sharry/restserver/routes/NotifyRoutes.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/routes/NotifyRoutes.scala
@@ -14,6 +14,7 @@ import sharry.backend.mail.NotifyResult
 import sharry.backend.BackendApp
 import sharry.restserver.Config
 import sharry.restapi.model.BasicResult
+import sharry.restserver.http4s.ClientRequestInfo
 
 object NotifyRoutes {
 
@@ -30,7 +31,7 @@ object NotifyRoutes {
     HttpRoutes.of { case req @ POST -> Root / "notify" / Ident(id) =>
       token.account.alias match {
         case Some(alias) =>
-          val baseurl = cfg.baseUrl / "app" / "upload"
+          val baseurl = ClientRequestInfo.getBaseUrl(cfg, req) / "app" / "upload"
           for {
             _    <- logger.fdebug("Notify about alias upload")
             res  <- backend.mail.notifyAliasUpload(alias, id, baseurl)

--- a/modules/restserver/src/main/scala/sharry/restserver/routes/OpenShareRoutes.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/routes/OpenShareRoutes.scala
@@ -19,7 +19,7 @@ object OpenShareRoutes {
     HttpRoutes.of[F] {
       case req @ GET -> Root / Ident(id) =>
         val pw = SharryPassword(req)
-        ShareDetailResponse(dsl, backend, cfg, ShareId.publish(id), pw)
+        ShareDetailResponse(dsl, req, backend, cfg, ShareId.publish(id), pw)
 
       case req @ GET -> Root / Ident(id) / file / Ident(fid) =>
         val pw = SharryPassword(req)

--- a/modules/restserver/src/main/scala/sharry/restserver/routes/ShareDetailResponse.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/routes/ShareDetailResponse.scala
@@ -12,11 +12,15 @@ import sharry.backend.share._
 import sharry.backend.BackendApp
 import sharry.restapi.model.{ShareDetail => ShareDetailDto, _}
 import sharry.restserver.Config
+import sharry.restserver.http4s.ClientRequestInfo
 
 object ShareDetailResponse {
+  private def getBaseUrl[F[_]](cfg: Config, req: Request[F]): LenientUri =
+    ClientRequestInfo.getBaseUrl(cfg, req)
 
   def apply[F[_]: Sync](
       dsl: Http4sDsl[F],
+      req: Request[F],
       backend: BackendApp[F],
       cfg: Config,
       shareId: ShareId,
@@ -25,8 +29,8 @@ object ShareDetailResponse {
     import dsl._
 
     val baseUri = shareId.fold(
-      pub => cfg.baseUrl / "api" / "v2" / "open" / "share" / pub.id.id / "file",
-      priv => cfg.baseUrl / "api" / "v2" / "sec" / "share" / priv.id.id / "file"
+      pub => getBaseUrl(cfg, req) / "api" / "v2" / "open" / "share" / pub.id.id / "file",
+      priv => getBaseUrl(cfg, req) / "api" / "v2" / "sec" / "share" / priv.id.id / "file"
     )
 
     val authChallenge = `WWW-Authenticate`(Challenge("sharry", "sharry"))

--- a/modules/restserver/src/main/scala/sharry/restserver/routes/ShareRoutes.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/routes/ShareRoutes.scala
@@ -43,7 +43,14 @@ object ShareRoutes {
 
       case req @ GET -> Root / Ident(id) =>
         val pw = SharryPassword(req)
-        ShareDetailResponse(dsl, backend, cfg, ShareId.secured(id, token.account), pw)
+        ShareDetailResponse(
+          dsl,
+          req,
+          backend,
+          cfg,
+          ShareId.secured(id, token.account),
+          pw
+        )
 
       case req @ POST -> Root / Ident(id) / "publish" =>
         (for {

--- a/modules/webapp/src/main/elm/App/Data.elm
+++ b/modules/webapp/src/main/elm/App/Data.elm
@@ -50,8 +50,11 @@ type alias Model =
 
 
 init : Key -> Url -> Flags -> Model
-init key url flags =
+init key url flags_ =
     let
+        flags =
+            initBaseUrl url flags_
+
         page =
             Page.fromUrl url |> Maybe.withDefault HomePage
     in
@@ -103,6 +106,26 @@ type Msg
     | UploadStoppedMsg (Maybe String)
     | ReceiveLanguage String
     | LangChooseMsg Comp.LanguageChoose.Msg
+
+
+initBaseUrl : Url -> Flags -> Flags
+initBaseUrl url flags_ =
+    let
+        cfg =
+            flags_.config
+
+        baseUrl =
+            if cfg.baseUrl == "" then
+                Url.toString
+                    { url | path = "", query = Nothing, fragment = Nothing }
+
+            else
+                cfg.baseUrl
+
+        cfgNew =
+            { cfg | baseUrl = baseUrl }
+    in
+    { flags_ | config = cfgNew }
 
 
 isSignedIn : Flags -> Bool


### PR DESCRIPTION
To better support access from other machines and for improving startup
experience, the base-url is determined using the request if the
setting is left at its default value (i.e. if the address is
`localhost`). If the `base-url` setting is changed, the behavior is as
before – the base-url is send to the client which uses it to create
requests.

The domain attribute of the cookie is removed, as the default behavior
is better as it excludes subdomains. The cookie will be only send to
the exact same origin.