### PR TITLE
Render sandboxed iframe for all files except pdfs

### DIFF
--- a/modules/webapp/src/main/elm/Comp/Zoom.elm
+++ b/modules/webapp/src/main/elm/Comp/Zoom.elm
@@ -126,10 +126,23 @@ filePreview fileUrl _ file =
             ]
             []
 
+    else if isPdf file then
+        div [ class "dark:bg-warmgray-300 bg-white" ]
+            [ iframe
+                [ src url
+                , sandbox "allow-scripts"
+                , class "w-full"
+                , attribute "width" "100%"
+                , attribute "height" "100%"
+                ]
+                []
+            ]
+
     else
         div [ class "dark:bg-warmgray-300 bg-white" ]
             [ iframe
                 [ src url
+                , sandbox ""
                 , class "w-full"
                 , attribute "width" "100%"
                 , attribute "height" "100%"


### PR DESCRIPTION
To let the browser render PDF files, `allow-scripts` is required. For
all other files (i.e. html files), everything is disallowed. Note that
PDF files can also contain (malicious) javascript code.