### PR TITLE
Use a classpath jar to reduce command length

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -225,7 +225,13 @@ val webapp = project
 
 val restserver = project
   .in(file("modules/restserver"))
-  .enablePlugins(BuildInfoPlugin, JavaServerAppPackaging, DebianPlugin, SystemdPlugin)
+  .enablePlugins(
+    BuildInfoPlugin,
+    JavaServerAppPackaging,
+    DebianPlugin,
+    SystemdPlugin,
+    ClasspathJarPlugin
+  )
   .settings(sharedSettings)
   .settings(testSettingsMUnit)
   .settings(debianSettings)


### PR DESCRIPTION
The long startup command is inconvenient and won't work on windows.
Now a jar file is created that contains the classpath.

https://sbt-native-packager.readthedocs.io/en/stable/recipes/longclasspath.html#generate-a-classpath-jar

Refs: #563