### PR TITLE
Added Azure AD example to OAuth

### DIFF
--- a/modules/restserver/src/main/resources/reference.conf
+++ b/modules/restserver/src/main/resources/reference.conf
@@ -190,12 +190,13 @@ sharry.restserver {
       # Uses OAuth2 "Code-Flow" for authentication against a
       # configured provider.
       #
-      # A provider (like Github or Google for example) must be
+      # A provider (like Github, Google, or Microsoft for example) must be
       # configured correctly for this to work. Each element in the array
       # results into a button on the login page.
       #
-      # Examples for Github and Google are provided below. You need to
-      # setup an “application” to obtain a client_secret and clien_id.
+      # Examples for Github, Google and Microsoft (Azure AD) are provided
+      # below. You need to setup an “application” to obtain a client_secret
+      # and client_id.
       #
       # Details:
       # - enabled: allows to toggle it on or off
@@ -234,6 +235,18 @@ sharry.restserver {
           token-url = "https://oauth2.googleapis.com/token"
           user-url = "https://www.googleapis.com/oauth2/v1/userinfo?alt=json"
           user-id-key = "name"
+          client-id = "<your client id>"
+          client-secret = "<your client secret>"
+        },
+        {
+          enabled = false
+          id = "aad"
+          name = "Azure AD"
+          icon = "fab fa-microsoft"
+          authorize-url = "https://login.microsoftonline.com/<your tenant ID>/oauth2/v2.0/authorize?scope=openid"
+          token-url = "https://login.microsoftonline.com/<your tenant ID>/oauth2/v2.0/token"
+          user-url = "https://graph.microsoft.com/oidc/userinfo"
+          user-id-key = "email"
           client-id = "<your client id>"
           client-secret = "<your client secret>"
         }


### PR DESCRIPTION
I've managed to get sharry authenticating against Microsoft Azure AD with the below config, thought I'd contribute it to the reference config file. Not sure if this would require updates to the documentation as well, let me know if you want me to have a crack at that.