### PR TITLE
Add dependency to have flyway work with mariadb

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -108,7 +108,8 @@ object Dependencies {
   // https://github.com/flyway/flyway
   // ASL 2.0
   val flyway = Seq(
-    "org.flywaydb" % "flyway-core" % FlywayVersion
+    "org.flywaydb" % "flyway-core" % FlywayVersion,
+    "org.flywaydb" % "flyway-mysql" % FlywayVersion
   )
 
   val yamusca = Seq(


### PR DESCRIPTION
The flyway library had a change where they excluded the mariadb
support from their core module.

Closes: #766 