### PR TITLE
Automatically redirect to oauth provider

### DIFF
--- a/modules/restapi/src/main/resources/sharry-openapi.yml
+++ b/modules/restapi/src/main/resources/sharry-openapi.yml
@@ -1922,6 +1922,7 @@ components:
         - aliasMemberEnabled
         - defaultValidity
         - initialTheme
+        - oauthAutoRedirect
       properties:
         appName:
           type: string
@@ -1987,6 +1988,8 @@ components:
         initialTheme:
           type: string
           format: theme
+        oauthAutoRedirect:
+          type: boolean
     OAuthItem:
       description: |
         Information about a configured OAuth provider.

--- a/modules/restserver/src/main/resources/reference.conf
+++ b/modules/restserver/src/main/resources/reference.conf
@@ -112,6 +112,12 @@ sharry.restserver {
 
     # The inital ui theme to use. Can be either 'light' or 'dark'.
     initial-theme = "light"
+
+    # When only OAuth is configured and only a single provider, then
+    # the weapp automatically redirects to its authentication page
+    # skipping the sharry login page. This will also disable the
+    # logout button, since sharry is not in charge anyways.
+    oauth-auto-redirect = true
   }
 
   backend {

--- a/modules/restserver/src/main/scala/sharry/restserver/config/Config.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/config/Config.scala
@@ -75,7 +75,8 @@ object Config {
       authRenewal: Duration,
       initialPage: String,
       defaultValidity: Duration,
-      initialTheme: String
+      initialTheme: String,
+      oauthAutoRedirect: Boolean
   )
 
   private def validateTheme(str: String): String =

--- a/modules/restserver/src/main/scala/sharry/restserver/routes/InfoRoutes.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/routes/InfoRoutes.scala
@@ -75,7 +75,8 @@ object InfoRoutes {
       cfg.backend.auth.isOAuthOnly,
       cfg.aliasMemberEnabled,
       cfg.webapp.defaultValidity,
-      cfg.webapp.initialTheme
+      cfg.webapp.initialTheme,
+      cfg.webapp.oauthAutoRedirect
     )
   }
 

--- a/modules/webapp/src/main/elm/App/Update.elm
+++ b/modules/webapp/src/main/elm/App/Update.elm
@@ -368,7 +368,7 @@ updateLogin : Page.Login.Data.Msg -> Model -> ( Model, Cmd Msg )
 updateLogin lmsg model =
     let
         ( lm, lc, ar ) =
-            Page.Login.Update.update (Page.loginPageReferrer model.page) model.flags lmsg model.loginModel
+            Page.Login.Update.update (Page.loginPageReferrer model.page) model.flags model.key lmsg model.loginModel
 
         newFlags =
             Maybe.map (Data.Flags.withAccount model.flags) ar

--- a/modules/webapp/src/main/elm/App/View.elm
+++ b/modules/webapp/src/main/elm/App/View.elm
@@ -2,6 +2,7 @@ module App.View exposing (view)
 
 import Api.Model.AuthResult exposing (AuthResult)
 import App.Data exposing (..)
+import Data.Flags
 import Data.UiTheme
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -263,7 +264,17 @@ userMenu2 texts model acc =
             , a
                 [ href "#"
                 , class dropdownItem
-                , onClick Logout
+                , classList [ ( "disabled", Data.Flags.isOAuthAutoRedirect model.flags ) ]
+                , if Data.Flags.isOAuthAutoRedirect model.flags then
+                    class ""
+
+                  else
+                    onClick Logout
+                , if Data.Flags.isOAuthAutoRedirect model.flags then
+                    title texts.app.logoutOAuth
+
+                  else
+                    title texts.app.logoutSharry
                 ]
                 [ i [ class "fa fa-sign-out-alt w-6" ] []
                 , span [ class "ml-1" ]

--- a/modules/webapp/src/main/elm/Data/Flags.elm
+++ b/modules/webapp/src/main/elm/Data/Flags.elm
@@ -17,6 +17,11 @@ type alias Flags =
     }
 
 
+isOAuthAutoRedirect : Flags -> Bool
+isOAuthAutoRedirect flags =
+    flags.config.oauthAutoRedirect && flags.config.oauthOnly
+
+
 getToken : Flags -> Maybe String
 getToken flags =
     flags.account

--- a/modules/webapp/src/main/elm/Messages/App.elm
+++ b/modules/webapp/src/main/elm/Messages/App.elm
@@ -17,6 +17,8 @@ type alias Texts =
     , login : String
     , register : String
     , lightDark : String
+    , logoutSharry : String
+    , logoutOAuth : String
     }
 
 
@@ -32,6 +34,8 @@ gb =
     , login = "Login"
     , register = "Register"
     , lightDark = "Light/Dark"
+    , logoutSharry = "Logout from Sharry"
+    , logoutOAuth = "Logout at your authentication provider"
     }
 
 
@@ -47,6 +51,8 @@ de =
     , login = "Anmelden"
     , register = "Registrieren"
     , lightDark = "Hell/Dunkel"
+    , logoutSharry = "Von Sharry abmelden"
+    , logoutOAuth = "Abmelden nur über den Authentifizierungs-Provider möglich"
     }
 
 
@@ -62,4 +68,6 @@ fr =
     , login = "Connexion"
     , register = "Inscription"
     , lightDark = gb.lightDark
+    , logoutSharry = "Déconnexion de Sharry"
+    , logoutOAuth = "Déconnexion de votre fournisseur d'authentification"
     }


### PR DESCRIPTION
There is a flag in the config (defaults to true) that would make the
webapp automatically redirect to the oauth provider, if only a single
one is configured and no other login modules are enabled.

Closes: #780