### PR TITLE
Configure the initial view for a share url

### DIFF
--- a/modules/webapp/src/main/elm/App/Update.elm
+++ b/modules/webapp/src/main/elm/App/Update.elm
@@ -5,6 +5,7 @@ import App.Data exposing (..)
 import Browser exposing (UrlRequest(..))
 import Browser.Navigation as Nav
 import Data.Flags
+import Data.InitialView exposing (InitialView)
 import Data.UiTheme
 import Page exposing (Page(..))
 import Page.Account.Data
@@ -90,7 +91,16 @@ update msg model =
             updateDetail lm model
 
         OpenDetailMsg lm ->
-            updateOpenDetail lm model
+            let
+                initialView =
+                    case model.page of
+                        Page.OpenDetailPage _ iv ->
+                            Data.InitialView.get iv
+
+                        _ ->
+                            Data.InitialView.default
+            in
+            updateOpenDetail initialView lm model
 
         SetPage p ->
             ( { model | page = p }
@@ -246,11 +256,11 @@ update msg model =
             )
 
 
-updateOpenDetail : Page.OpenDetail.Data.Msg -> Model -> ( Model, Cmd Msg )
-updateOpenDetail lmsg model =
+updateOpenDetail : InitialView -> Page.OpenDetail.Data.Msg -> Model -> ( Model, Cmd Msg )
+updateOpenDetail initialView lmsg model =
     let
         ( lm, lc ) =
-            Page.OpenDetail.Update.update model.flags lmsg model.openDetailModel
+            Page.OpenDetail.Update.update model.flags initialView lmsg model.openDetailModel
     in
     ( { model | openDetailModel = lm }
     , Cmd.map OpenDetailMsg lc
@@ -440,5 +450,5 @@ initPage model page =
         DetailPage id ->
             updateDetail (Page.Detail.Data.Init id) model
 
-        OpenDetailPage id ->
-            updateOpenDetail (Page.OpenDetail.Data.Init id) model
+        OpenDetailPage id initialView ->
+            updateOpenDetail (Data.InitialView.get initialView) (Page.OpenDetail.Data.Init id) model

--- a/modules/webapp/src/main/elm/App/View.elm
+++ b/modules/webapp/src/main/elm/App/View.elm
@@ -3,6 +3,7 @@ module App.View exposing (view)
 import Api.Model.AuthResult exposing (AuthResult)
 import App.Data exposing (..)
 import Data.Flags
+import Data.InitialView exposing (InitialView)
 import Data.UiTheme
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -328,7 +329,7 @@ mainContent texts model =
             DetailPage id ->
                 viewDetail id texts model
 
-            OpenDetailPage id ->
+            OpenDetailPage id _ ->
                 viewOpenDetail id texts model
         ]
 

--- a/modules/webapp/src/main/elm/Data/InitialView.elm
+++ b/modules/webapp/src/main/elm/Data/InitialView.elm
@@ -1,0 +1,53 @@
+module Data.InitialView exposing (InitialView(..), all, default, fromInt, get, icon, toInt)
+
+
+type InitialView
+    = Listing
+    | Cards
+    | Zoom
+
+
+all : List InitialView
+all =
+    [ Listing, Cards, Zoom ]
+
+
+toInt : InitialView -> Int
+toInt view =
+    case view of
+        Listing ->
+            1
+
+        Cards ->
+            2
+
+        Zoom ->
+            3
+
+
+default : InitialView
+default =
+    Listing
+
+
+fromInt : Int -> Maybe InitialView
+fromInt n =
+    List.filter (\e -> toInt e == n) all |> List.head
+
+
+get : Maybe Int -> InitialView
+get n =
+    Maybe.andThen fromInt n |> Maybe.withDefault default
+
+
+icon : InitialView -> String
+icon iv =
+    case iv of
+        Listing ->
+            "fa fa-list"
+
+        Cards ->
+            "fa fa-th"
+
+        Zoom ->
+            "fa fa-eye"

--- a/modules/webapp/src/main/elm/Messages/DetailPage.elm
+++ b/modules/webapp/src/main/elm/Messages/DetailPage.elm
@@ -5,6 +5,7 @@ module Messages.DetailPage exposing
     , gb
     )
 
+import Data.InitialView exposing (InitialView)
 import Language
 import Messages.DateFormat
 import Messages.Dropzone2
@@ -68,6 +69,8 @@ type alias Texts =
     , passwordInvalid : String
     , or : String
     , dateTime : Int -> String
+    , initialViewLabel : InitialView -> String
+    , initialViewField : String
     }
 
 
@@ -134,6 +137,18 @@ gb =
     , passwordInvalid = "Password invalid"
     , or = "Or"
     , dateTime = Messages.DateFormat.formatDateTime Language.English
+    , initialViewLabel =
+        \iv ->
+            case iv of
+                Data.InitialView.Listing ->
+                    "Listing"
+
+                Data.InitialView.Cards ->
+                    "Cards"
+
+                Data.InitialView.Zoom ->
+                    "Preview"
+    , initialViewField = "Initial view"
     }
 
 
@@ -201,7 +216,23 @@ de =
     , passwordInvalid = "Passwort ungültig"
     , or = "Oder"
     , dateTime = Messages.DateFormat.formatDateTime Language.German
+    , initialViewLabel =
+        \iv ->
+            case iv of
+                Data.InitialView.Listing ->
+                    "Liste"
+
+                Data.InitialView.Cards ->
+                    "Kacheln"
+
+                Data.InitialView.Zoom ->
+                    "Vorschau"
+    , initialViewField = "Anfangsansicht"
     }
+
+
+
+-- TODO check French translations
 
 
 fr : Texts
@@ -267,4 +298,16 @@ fr =
     , passwordInvalid = "Mot de passe invalide"
     , or = "Ou"
     , dateTime = Messages.DateFormat.formatDateTime Language.French
+    , initialViewLabel =
+        \iv ->
+            case iv of
+                Data.InitialView.Listing ->
+                    "Listing"
+
+                Data.InitialView.Cards ->
+                    "Cards"
+
+                Data.InitialView.Zoom ->
+                    "Preview"
+    , initialViewField = "Initial view"
     }

--- a/modules/webapp/src/main/elm/Page.elm
+++ b/modules/webapp/src/main/elm/Page.elm
@@ -36,7 +36,7 @@ type Page
     | OpenSharePage String
     | SettingsPage
     | DetailPage String
-    | OpenDetailPage String
+    | OpenDetailPage String (Maybe Int)
 
 
 isSecured : Page -> Bool
@@ -78,7 +78,7 @@ isSecured page =
         DetailPage _ ->
             True
 
-        OpenDetailPage _ ->
+        OpenDetailPage _ _ ->
             False
 
 
@@ -142,7 +142,7 @@ pageToString page =
         HomePage ->
             "/app/home"
 
-        LoginPage ( referer, oauth ) ->
+        LoginPage ( referer, _ ) ->
             Maybe.map (\p -> "?r=" ++ p) referer
                 |> Maybe.withDefault ""
                 |> (++) "/app/login"
@@ -187,8 +187,17 @@ pageToString page =
         DetailPage id ->
             "/app/upload/" ++ id
 
-        OpenDetailPage id ->
-            "/app/open/" ++ id
+        OpenDetailPage id initialView ->
+            let
+                viewParam =
+                    case initialView of
+                        Just n ->
+                            "?view=" ++ String.fromInt n
+
+                        Nothing ->
+                            ""
+            in
+            "/app/open/" ++ id ++ viewParam
 
 
 pageFromString : String -> Maybe Page
@@ -245,7 +254,7 @@ parser =
         , Parser.map OpenSharePage (s pathPrefix </> s "share" </> string)
         , Parser.map SharePage (s pathPrefix </> s "share")
         , Parser.map SettingsPage (s pathPrefix </> s "settings")
-        , Parser.map OpenDetailPage (s pathPrefix </> s "open" </> string)
+        , Parser.map OpenDetailPage (s pathPrefix </> s "open" </> string <?> Query.int "view")
         ]
 
 

--- a/modules/webapp/src/main/elm/Page/Detail/Data.elm
+++ b/modules/webapp/src/main/elm/Page/Detail/Data.elm
@@ -26,6 +26,7 @@ import Comp.PasswordInput
 import Comp.ShareFileList
 import Comp.ValidityField
 import Data.Flags exposing (Flags)
+import Data.InitialView exposing (InitialView)
 import Data.UploadDict exposing (UploadDict)
 import Data.UploadState exposing (UploadState)
 import Data.ValidityValue exposing (ValidityValue)
@@ -49,6 +50,7 @@ type alias Model =
     , uploadPaused : Bool
     , uploadFormState : BasicResult
     , mailForm : Maybe Comp.MailSend.Model
+    , shareUrlMode : InitialView
     }
 
 
@@ -109,6 +111,7 @@ emptyModel =
     , uploadPaused = True
     , uploadFormState = BasicResult True ""
     , mailForm = Nothing
+    , shareUrlMode = Data.InitialView.default
     }
 
 
@@ -191,6 +194,7 @@ type Msg
     | InitMail
     | CopyToClipboard String
     | EditKey (Maybe KeyCode)
+    | SetShareUrlMode InitialView
 
 
 isPublished : ShareDetail -> PublishState

--- a/modules/webapp/src/main/elm/Page/Detail/Update.elm
+++ b/modules/webapp/src/main/elm/Page/Detail/Update.elm
@@ -467,6 +467,9 @@ update flags msg model =
         CopyToClipboard _ ->
             ( model, Cmd.none )
 
+        SetShareUrlMode iv ->
+            ( { model | shareUrlMode = iv }, Cmd.none )
+
 
 trackUpload : Model -> UploadState -> Model
 trackUpload model state =

--- a/modules/webapp/src/main/elm/Page/Detail/View.elm
+++ b/modules/webapp/src/main/elm/Page/Detail/View.elm
@@ -14,6 +14,7 @@ import Comp.ShareFileList exposing (ViewMode(..))
 import Comp.ValidityField
 import Comp.Zoom
 import Data.Flags exposing (Flags)
+import Data.InitialView
 import Data.ValidityOptions
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -171,7 +172,7 @@ shareLinkPublished texts flags model =
                 |> Maybe.withDefault ""
 
         url =
-            flags.config.baseUrl ++ Page.pageToString (OpenDetailPage pid)
+            flags.config.baseUrl ++ Page.pageToString (OpenDetailPage pid (Just <| Data.InitialView.toInt model.shareUrlMode))
 
         qrCodeView : String -> Html msg
         qrCodeView message =
@@ -191,6 +192,12 @@ shareLinkPublished texts flags model =
                 ]
             ]
         , text texts.shareAsYouLike
+        ]
+    , div [ class "flex flex-row space-x-2 items-center" ]
+        [ div [ class "flex-grow text-right" ]
+            [ text texts.initialViewField
+            ]
+        , showUrlSwitch texts model
         ]
     , case model.mailForm of
         Just mf ->
@@ -237,6 +244,27 @@ shareLinkPublished texts flags model =
                     ]
                 ]
     ]
+
+
+showUrlSwitch : Texts -> Model -> Html Msg
+showUrlSwitch texts model =
+    MB.view
+        { start = []
+        , end =
+            List.map
+                (\iv ->
+                    MB.ToggleButton
+                        { tagger = SetShareUrlMode iv
+                        , title = texts.initialViewLabel iv
+                        , icon = Just <| Data.InitialView.icon iv
+                        , label = texts.initialViewLabel iv
+                        , active = model.shareUrlMode == iv
+                        }
+                )
+                Data.InitialView.all
+        , rootClasses = "py-1 text-xs"
+        , sticky = False
+        }
 
 
 messageDiv : Model -> Html Msg

--- a/modules/webapp/src/main/elm/Page/OpenDetail/View.elm
+++ b/modules/webapp/src/main/elm/Page/OpenDetail/View.elm
@@ -138,11 +138,14 @@ fileList texts flags model =
                 (Api.fileOpenUrl flags (shareId model) "")
                 model.fileView
                 False
+
+        sorted =
+            List.sortBy .filename model.share.files
     in
     Html.map FileListMsg <|
         Comp.ShareFileList.view texts.shareFileList
             sett
-            model.share.files
+            sorted
             model.fileListModel
 
 


### PR DESCRIPTION
When sharing an url, a query parameter can be used to specify which
view should be used: list view, card view or preview mode.

Closes: #778