### PR TITLE
Add Nix flakes support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,41 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1668912770,
+        "narHash": "sha256-Nzt7ALUl5PrUAYIH8aRbj+njkJZVQ4VQBkWx+qQvqyM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "862277ac9d34273cd953f42061e23d488d6b7e8b",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "Sharry allows to share files with others in a simple way";
+
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+  let
+    release = import nix/release.nix;
+  in
+  {
+    overlays.default = final: prev: {
+      sharryVersions = builtins.mapAttrs (_: cfg: final.callPackage (release.pkg cfg) { }) release.cfg;
+      sharry = final.callPackage release.currentPkg { };
+    };
+    nixosModules.default = release.module;
+  } // flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs { inherit system; overlays = [ self.overlays.default ]; };
+    in
+    {
+      packages = {
+        inherit (pkgs) sharry;
+        default = self.packages."${system}".sharry;
+      } // pkgs.sharryVersions;
+    }
+  );
+}


### PR DESCRIPTION
This adds a simple flake that wraps around the existing release.nix in the `nix/` subdirectory.