### PR TITLE
Fix counting password protected shares twice

### DIFF
--- a/modules/webapp/src/main/elm/Page/OpenDetail/View.elm
+++ b/modules/webapp/src/main/elm/Page/OpenDetail/View.elm
@@ -70,7 +70,6 @@ passwordDialog texts model =
                     , class "ml-2 block"
                     , href "#"
                     , type_ "submit"
-                    , onClick SubmitPassword
                     ]
                     [ text texts.submit
                     ]


### PR DESCRIPTION
The webui initiated two request with a correct password, which incremented the counter twice.

Closes: 991