### PR TITLE
add a healthcheck for the db and change the depends_on to wait for condition service_healthy

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,8 @@ services:
     volumes:
       - ${PWD}/sharry.conf:/opt/sharry.conf
     depends_on:
-      - db
+      db:
+        condition: service_healthy
   db:
     image: postgres:16.4
     container_name: postgres_db
@@ -19,5 +20,12 @@ services:
       - POSTGRES_USER=dbuser
       - POSTGRES_PASSWORD=dbpass
       - POSTGRES_DB=dbname
+      - PGUSER=dbuser
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready", "-d", "dbname"]
+      interval: 15s
+      timeout: 60s
+      retries: 5
+      start_period: 15s
 volumes:
   postgres_data:


### PR DESCRIPTION
I had the same error multiple times during testing, that the db is not yet ready, but the container was started. So docker compose started the sharry container which errored out as the database was not found/ready.

This fixed it in my tests.