### PR TITLE
Fix invalid syntax in db healthcheck in docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,10 +22,10 @@ services:
       - POSTGRES_DB=dbname
       - PGUSER=dbuser
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready", "-d", "dbname"]
+      test: pg_isready -q -d dbname
       interval: 15s
-      timeout: 60s
-      retries: 5
+      timeout: 5s # pg_isready has a 3 second timeout by default so actually this doesn't matter very much
+      retries: 3
       start_period: 15s
 volumes:
   postgres_data:


### PR DESCRIPTION
Fixes #1566

`CMD-SHELL` [expects](https://docs.docker.com/reference/compose-file/services/#healthcheck) a single string as the second element, not split arguments. Correct usage would have been `["CMD-SHELL", "pg_isready -d dbname"]` but for simple commands like this I like to drop the array as Docker interprets strings as shell form. I also lowered the timeout and retries to more sensible values.