### PR TITLE
Fix checkbox visibility in dark mode

### DIFF
--- a/modules/webapp/src/main/elm/Styles.elm
+++ b/modules/webapp/src/main/elm/Styles.elm
@@ -277,7 +277,7 @@ inputLeftIconOnly =
 
 checkboxInput : String
 checkboxInput =
-    " checkbox w-5 h-5 md:w-4 md:h-4 text-black  dark:text-stone-600 dark:bg-stone-600 dark:border-stone-700" ++ formFocusRing
+    " checkbox w-5 h-5 md:w-4 md:h-4 text-black dark:text-sky-500 dark:bg-stone-600 dark:border-stone-700" ++ formFocusRing
 
 
 formFocusRing : String

--- a/project/StylesPlugin.scala
+++ b/project/StylesPlugin.scala
@@ -86,7 +86,11 @@ object StylesPlugin extends AutoPlugin {
     val modulesDir = wd / "node_modules"
     if (!modulesDir.exists) {
       logger.info("Running npm install …")
-      Cmd.run(Seq(npm, "install"), wd, logger)
+      val npmCmd = if (sys.props.getOrElse("os.name", "").toLowerCase.contains("windows"))
+        Seq("cmd", "/c", npm)
+      else
+        Seq(npm)
+      Cmd.run(npmCmd ++ Seq("install"), wd, logger)
     }
   }
 
@@ -104,8 +108,11 @@ object StylesPlugin extends AutoPlugin {
     }
     val target = outDir / "css" / "styles.css"
     IO.createDirectory(target.getParentFile)
-    val cmd = Seq(
-      tailwind,
+    val twCmd = if (sys.props.getOrElse("os.name", "").toLowerCase.contains("windows"))
+      Seq("cmd", "/c", tailwind)
+    else
+      Seq(tailwind)
+    val cmd = twCmd ++ Seq(
       "--input",
       s"$inDir/index.css",
       "-o",

--- a/project/StylesPlugin.scala
+++ b/project/StylesPlugin.scala
@@ -86,10 +86,11 @@ object StylesPlugin extends AutoPlugin {
     val modulesDir = wd / "node_modules"
     if (!modulesDir.exists) {
       logger.info("Running npm install …")
-      val npmCmd = if (sys.props.getOrElse("os.name", "").toLowerCase.contains("windows"))
-        Seq("cmd", "/c", npm)
-      else
-        Seq(npm)
+      val npmCmd =
+        if (sys.props.getOrElse("os.name", "").toLowerCase.contains("windows"))
+          Seq("cmd", "/c", npm)
+        else
+          Seq(npm)
       Cmd.run(npmCmd ++ Seq("install"), wd, logger)
     }
   }
@@ -108,10 +109,11 @@ object StylesPlugin extends AutoPlugin {
     }
     val target = outDir / "css" / "styles.css"
     IO.createDirectory(target.getParentFile)
-    val twCmd = if (sys.props.getOrElse("os.name", "").toLowerCase.contains("windows"))
-      Seq("cmd", "/c", tailwind)
-    else
-      Seq(tailwind)
+    val twCmd =
+      if (sys.props.getOrElse("os.name", "").toLowerCase.contains("windows"))
+        Seq("cmd", "/c", tailwind)
+      else
+        Seq(tailwind)
     val cmd = twCmd ++ Seq(
       "--input",
       s"$inDir/index.css",


### PR DESCRIPTION
fix(webapp): make checkbox visible in dark mode

text-stone-600 matched bg-stone-600, hiding the checkmark.
sky-500 provides contrast against the dark background.

build: wrap tailwindcss/npm with cmd /c on Windows
ProcessBuilder does not resolve .cmd files via PATH on Windows.