### PR TITLE
Download all files as zip

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -180,6 +180,7 @@ val restapi = project
   .settings(testSettingsMUnit)
   .settings(
     name := "sharry-restapi",
+    scalacOptions += "-Xmax-inlines:64",
     libraryDependencies ++=
       Dependencies.circe,
     openapiTargetLanguage := Language.Scala,

--- a/modules/backend/src/main/scala/sharry/backend/share/OShare.scala
+++ b/modules/backend/src/main/scala/sharry/backend/share/OShare.scala
@@ -421,7 +421,8 @@ object OShare {
                     .findBinary(file.metaId, binny.ByteRange.All)
                     .semiflatMap(
                       _.through(
-                        fsio.writeOutputStream[F](Async[F].pure(zos), closeAfterUse = false)
+                        fsio
+                          .writeOutputStream[F](Async[F].pure(zos), closeAfterUse = false)
                       ).compile.drain
                     )
                     .getOrElse(()) *>

--- a/modules/backend/src/main/scala/sharry/backend/share/OShare.scala
+++ b/modules/backend/src/main/scala/sharry/backend/share/OShare.scala
@@ -112,9 +112,8 @@ trait OShare[F[_]] {
   ): OptionT[F, FileRange[F]]
 
   def loadZip(
-      id: ShareId,
-      pass: Option[Password]
-  ): OptionT[F, ShareResult[Stream[F, Byte]]]
+      id: ShareId
+  ): OptionT[F, Stream[F, Byte]]
 
   def deleteFile(accId: AccountId, file: Ident): OptionT[F, Unit]
 
@@ -404,12 +403,11 @@ object OShare {
       }
 
       def loadZip(
-          id: ShareId,
-          pass: Option[Password]
-      ): OptionT[F, ShareResult[Stream[F, Byte]]] =
+          id: ShareId
+      ): OptionT[F, Stream[F, Byte]] =
         for {
-          result <- shareDetails(id, pass)
-        } yield result.map { sd =>
+          sd <- OptionT(store.transact(Queries.shareDetail(id).value))
+        } yield {
           val chunkSize = cfg.chunkSize.bytes.toInt
           fsio.readOutputStream[F](chunkSize) { os =>
             val zos = new java.util.zip.ZipOutputStream(os)

--- a/modules/backend/src/main/scala/sharry/backend/share/OShare.scala
+++ b/modules/backend/src/main/scala/sharry/backend/share/OShare.scala
@@ -404,9 +404,13 @@ object OShare {
 
       def loadZip(
           id: ShareId
-      ): OptionT[F, Stream[F, Byte]] =
+      ): OptionT[F, Stream[F, Byte]] = {
+        val limit = cfg.zipMaxSize.bytes
         for {
+          _ <- OptionT.fromOption[F](Option.when(limit > 0)(()))
           sd <- OptionT(store.transact(Queries.shareDetail(id).value))
+          totalSize = sd.files.map(_.length.bytes).sum
+          _ <- OptionT.fromOption[F](Option.when(totalSize <= limit)(()))
         } yield {
           val chunkSize = cfg.chunkSize.bytes.toInt
           fsio.readOutputStream[F](chunkSize) { os =>
@@ -429,6 +433,7 @@ object OShare {
               Async[F].delay(zos.close())
           }
         }
+      }
 
       def deleteFile(accId: AccountId, file: Ident): OptionT[F, Unit] =
         for {

--- a/modules/backend/src/main/scala/sharry/backend/share/OShare.scala
+++ b/modules/backend/src/main/scala/sharry/backend/share/OShare.scala
@@ -4,6 +4,7 @@ import cats.data.OptionT
 import cats.effect.*
 import cats.implicits.*
 import fs2.Stream
+import fs2.io as fsio
 
 import sharry.backend.PasswordCrypt
 import sharry.common.*
@@ -109,6 +110,11 @@ trait OShare[F[_]] {
       pass: Option[Password],
       range: ByteRange
   ): OptionT[F, FileRange[F]]
+
+  def loadZip(
+      id: ShareId,
+      pass: Option[Password]
+  ): OptionT[F, ShareResult[Stream[F, Byte]]]
 
   def deleteFile(accId: AccountId, file: Ident): OptionT[F, Unit]
 
@@ -396,6 +402,34 @@ object OShare {
           file <- ByteResult.load(store)(file, range)
         } yield file
       }
+
+      def loadZip(
+          id: ShareId,
+          pass: Option[Password]
+      ): OptionT[F, ShareResult[Stream[F, Byte]]] =
+        for {
+          result <- shareDetails(id, pass)
+        } yield result.map { sd =>
+          val chunkSize = cfg.chunkSize.bytes.toInt
+          fsio.readOutputStream[F](chunkSize) { os =>
+            val zos = new java.util.zip.ZipOutputStream(os)
+            sd.files.toList
+              .traverse_ { file =>
+                val entryName = file.name.getOrElse(file.id.id)
+                Async[F].delay(zos.putNextEntry(new java.util.zip.ZipEntry(entryName))) *>
+                  store.fileStore
+                    .findBinary(file.metaId, binny.ByteRange.All)
+                    .semiflatMap(
+                      _.through(
+                        fsio.writeOutputStream[F](Async[F].pure(zos), closeAfterUse = false)
+                      ).compile.drain
+                    )
+                    .getOrElse(()) *>
+                  Async[F].delay(zos.closeEntry())
+              } *>
+              Async[F].delay(zos.close())
+          }
+        }
 
       def deleteFile(accId: AccountId, file: Ident): OptionT[F, Unit] =
         for {

--- a/modules/backend/src/main/scala/sharry/backend/share/ShareConfig.scala
+++ b/modules/backend/src/main/scala/sharry/backend/share/ShareConfig.scala
@@ -7,5 +7,6 @@ case class ShareConfig(
     chunkSize: ByteSize,
     maxSize: ByteSize,
     maxValidity: Duration,
-    databaseDomainChecks: Seq[DomainCheckConfig]
+    databaseDomainChecks: Seq[DomainCheckConfig],
+    zipMaxSize: ByteSize
 )

--- a/modules/microsite/docs/doc/configure.md
+++ b/modules/microsite/docs/doc/configure.md
@@ -160,6 +160,26 @@ The following steps must be done manually:
 Then add the above setting into your config file. Test files can be
 found [here](https://www.eicar.org/?page_id=3950).
 
+### ZIP Download
+
+The `zip-max-size` setting controls whether users can download all
+files of a share as a single ZIP archive.
+
+```
+sharry.restserver.backend.share {
+  # Maximum total size of a share allowed for ZIP download.
+  # Set to "0" to disable the ZIP download feature entirely.
+  # If this value exceeds max-size, it is automatically capped to
+  # max-size at startup (a warning is logged in that case).
+  zip-max-size = "1.5G"
+}
+```
+
+Set `zip-max-size = "0"` to disable the ZIP download button entirely.
+If a share's total size exceeds this value, the download-as-ZIP option
+is hidden. The value cannot exceed `max-size`; if it does, it is
+silently capped at startup.
+
 ### Files
 
 By default, the files are also stored in the configured database. This

--- a/modules/microsite/docs/doc/webapp.md
+++ b/modules/microsite/docs/doc/webapp.md
@@ -120,6 +120,16 @@ the download page is accessed more than this number, it will not work
 anymore.
 
 
+### Download All as ZIP
+
+When a share is published, the download page shows a *Download All*
+button that lets visitors download all files in the share as a single
+ZIP archive. The button is only shown when the total size of the share
+is within the limit configured by `zip-max-size` (see
+[configuration](configure#zip-download)). If the administrator has set
+`zip-max-size = "0"`, the button is hidden entirely.
+
+
 ## Publish / Unpublish / Republish
 
 A share that has not been published can only be accessed by its owner.

--- a/modules/restapi/src/main/resources/sharry-openapi.yml
+++ b/modules/restapi/src/main/resources/sharry-openapi.yml
@@ -1124,6 +1124,58 @@ paths:
               schema:
                 $ref: "#/components/schemas/BasicResult"
 
+  /open/share/{pid}/zip:
+    get:
+      operationId: "open-share-pid-zip-get"
+      tags:
+        - Shares (Public)
+      summary: Download all files of a share as a ZIP archive.
+      description: |
+        Streams all files of a share as a single ZIP archive.
+
+        The response is a ZIP file containing all files of the share.
+      parameters:
+        - $ref: "#/components/parameters/pid"
+      responses:
+        422:
+          description: BadRequest
+        404:
+          description: NotFound
+        200:
+          description: Ok
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+
+  /sec/share/{id}/zip:
+    get:
+      operationId: "sec-share-id-zip-get"
+      tags:
+        - Shares
+      summary: Download all files of a share as a ZIP archive.
+      description: |
+        Streams all files of a share as a single ZIP archive.
+
+        The response is a ZIP file containing all files of the share.
+      parameters:
+        - $ref: "#/components/parameters/id"
+      security:
+        - authTokenHeader: []
+      responses:
+        422:
+          description: BadRequest
+        404:
+          description: NotFound
+        200:
+          description: Ok
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+
   /alias/upload/{id}/files/tus:
     $ref: "#/paths/~1sec~1upload~1%7Bid%7D~1files~1tus"
 

--- a/modules/restapi/src/main/resources/sharry-openapi.yml
+++ b/modules/restapi/src/main/resources/sharry-openapi.yml
@@ -1133,14 +1133,16 @@ paths:
       description: |
         Streams all files of a share as a single ZIP archive.
 
-        The response is a ZIP file containing all files of the share.
+        Returns 404 if the share is not found, if the ZIP download feature is
+        disabled (zip-max-size = 0), or if the share's total size exceeds the
+        configured zip-max-size limit.
       parameters:
         - $ref: "#/components/parameters/pid"
       responses:
         422:
           description: BadRequest
         404:
-          description: NotFound
+          description: NotFound (also returned when ZIP download is disabled or share exceeds zip-max-size)
         200:
           description: Ok
           content:
@@ -1158,7 +1160,9 @@ paths:
       description: |
         Streams all files of a share as a single ZIP archive.
 
-        The response is a ZIP file containing all files of the share.
+        Returns 404 if the share is not found, if the ZIP download feature is
+        disabled (zip-max-size = 0), or if the share's total size exceeds the
+        configured zip-max-size limit.
       parameters:
         - $ref: "#/components/parameters/id"
       security:
@@ -1167,7 +1171,7 @@ paths:
         422:
           description: BadRequest
         404:
-          description: NotFound
+          description: NotFound (also returned when ZIP download is disabled or share exceeds zip-max-size)
         200:
           description: Ok
           content:
@@ -1995,6 +1999,7 @@ components:
         - proxyAuthEnabled
         - proxyOnly
         - hideLoginForm
+        - zipMaxSize
       properties:
         appName:
           type: string
@@ -2068,6 +2073,9 @@ components:
           type: boolean
         hideLoginForm:
           type: boolean
+        zipMaxSize:
+          type: integer
+          format: size
     OAuthItem:
       description: |
         Information about a configured OAuth provider.

--- a/modules/restserver/src/main/resources/reference.conf
+++ b/modules/restserver/src/main/resources/reference.conf
@@ -415,6 +415,12 @@ sharry.restserver {
       # Maximum validity for uploads
       max-validity = 365 days
 
+      # Maximum total size of a share allowed for ZIP download.
+      # Set to "0" to disable the ZIP download feature entirely.
+      # If this value exceeds max-size, it is automatically capped to
+      # max-size at startup (a warning is logged in that case).
+      zip-max-size = "1.5G"
+
       # Allows additional database checks to be translated into some
       # meaningful message to the user.
       #

--- a/modules/restserver/src/main/scala/sharry/restserver/Main.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/Main.scala
@@ -60,7 +60,8 @@ object Main extends IOApp {
         }
       }
 
-      cfg <- ConfigFile.loadConfig
+      rawCfg <- ConfigFile.loadConfig
+      (cfg, zipWarn) = rawCfg.normalizeZipMaxSize
 
       _ <- ScribeConfigure.configure[IO](cfg.logging)
 
@@ -75,6 +76,7 @@ object Main extends IOApp {
 
       _ <- logger.info(s"\n${banner.render("***>")}")
       _ <- logger.info(s"\n${cfg.backend.files.stores}\n")
+      _ <- zipWarn.fold(IO.unit)(msg => logger.warn(s"Configuration warning: $msg"))
 
       pools = connectEC.map(Pools.apply)
       _ <-

--- a/modules/restserver/src/main/scala/sharry/restserver/config/Config.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/config/Config.scala
@@ -49,6 +49,18 @@ case class Config(
       .mapN((_, _, _, c) => c)
   }
 
+  def normalizeZipMaxSize: (Config, Option[String]) = {
+    val zipMax = backend.share.zipMaxSize
+    val max = backend.share.maxSize
+    if (zipMax.bytes > 0 && zipMax > max) {
+      val normalized =
+        copy(backend = backend.copy(share = backend.share.copy(zipMaxSize = max)))
+      val msg =
+        s"zip-max-size (${zipMax.toHuman}) exceeds max-size (${max.toHuman}); capping to ${max.toHuman}"
+      (normalized, Some(msg))
+    } else (this, None)
+  }
+
   def validOrThrow: Config =
     validate match {
       case Validated.Valid(cfg)    => cfg

--- a/modules/restserver/src/main/scala/sharry/restserver/config/ConfigValues.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/config/ConfigValues.scala
@@ -357,7 +357,8 @@ object ConfigValues extends ConfigDecoders:
       "BACKEND_SHARE_DATABASE_DOMAIN_CHECKS_IDS"
     )
       .listflatMap(domainCheck)
-    (chunkSize, maxSize, maxValid, domainChecks).mapN(ShareConfig.apply)
+    val zipMaxSize = k("zip-max-size", "ZIP_MAX_SIZE").as[ByteSize]
+    (chunkSize, maxSize, maxValid, domainChecks, zipMaxSize).mapN(ShareConfig.apply)
   }
 
   val cleanup = {

--- a/modules/restserver/src/main/scala/sharry/restserver/routes/InfoRoutes.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/routes/InfoRoutes.scala
@@ -79,7 +79,8 @@ object InfoRoutes {
       cfg.webapp.oauthAutoRedirect,
       cfg.backend.auth.proxy.enabled,
       cfg.backend.auth.isProxyAuthOnly,
-      cfg.backend.auth.isAutoLogin
+      cfg.backend.auth.isAutoLogin,
+      cfg.backend.share.zipMaxSize
     )
   }
 

--- a/modules/restserver/src/main/scala/sharry/restserver/routes/OpenShareRoutes.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/routes/OpenShareRoutes.scala
@@ -13,7 +13,6 @@ import sharry.restserver.routes.headers.SharryPassword
 import org.http4s.*
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.*
-import org.http4s.headers.`WWW-Authenticate`
 import org.typelevel.ci.CIString
 
 object OpenShareRoutes {
@@ -38,25 +37,17 @@ object OpenShareRoutes {
         ByteResponse(dsl, req, backend, ShareId.publish(id), pw, chunkSize, fid)
 
       case req @ GET -> Root / Ident(id) / "zip" =>
-        val pw = SharryPassword(req)
-        val shareId = ShareId.publish(id)
-        val authChallenge = `WWW-Authenticate`(Challenge("sharry", "sharry"))
         (for {
-          result <- backend.share.loadZip(shareId, pw)
+          stream <- backend.share.loadZip(ShareId.publish(id))
           resp <- OptionT.liftF(
-            result.fold(
-              stream =>
-                Ok(stream).map(
-                  _.withHeaders(
-                    `Content-Type`(MediaType.application.zip),
-                    `Content-Disposition`(
-                      "attachment",
-                      Map(CIString("filename") -> s"$id.zip")
-                    )
-                  )
-                ),
-              _ => dsl.Forbidden(),
-              _ => dsl.Unauthorized(authChallenge)
+            Ok(stream).map(
+              _.withHeaders(
+                `Content-Type`(MediaType.application.zip),
+                `Content-Disposition`(
+                  "attachment",
+                  Map(CIString("filename") -> s"$id.zip")
+                )
+              )
             )
           )
         } yield resp).getOrElseF(dsl.NotFound())

--- a/modules/restserver/src/main/scala/sharry/restserver/routes/OpenShareRoutes.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/routes/OpenShareRoutes.scala
@@ -1,6 +1,8 @@
 package sharry.restserver.routes
 
+import cats.data.OptionT
 import cats.effect.*
+import cats.implicits.*
 
 import sharry.backend.BackendApp
 import sharry.backend.share.*
@@ -10,6 +12,9 @@ import sharry.restserver.routes.headers.SharryPassword
 
 import org.http4s.*
 import org.http4s.dsl.Http4sDsl
+import org.http4s.headers.*
+import org.http4s.headers.`WWW-Authenticate`
+import org.typelevel.ci.CIString
 
 object OpenShareRoutes {
 
@@ -31,6 +36,30 @@ object OpenShareRoutes {
         val pw = SharryPassword(req)
         val chunkSize = cfg.fileDownload.downloadChunkSize
         ByteResponse(dsl, req, backend, ShareId.publish(id), pw, chunkSize, fid)
+
+      case req @ GET -> Root / Ident(id) / "zip" =>
+        val pw = SharryPassword(req)
+        val shareId = ShareId.publish(id)
+        val authChallenge = `WWW-Authenticate`(Challenge("sharry", "sharry"))
+        (for {
+          result <- backend.share.loadZip(shareId, pw)
+          resp <- OptionT.liftF(
+            result.fold(
+              stream =>
+                Ok(stream).map(
+                  _.withHeaders(
+                    `Content-Type`(MediaType.application.zip),
+                    `Content-Disposition`(
+                      "attachment",
+                      Map(CIString("filename") -> s"$id.zip")
+                    )
+                  )
+                ),
+              _ => dsl.Forbidden(),
+              _ => dsl.Unauthorized(authChallenge)
+            )
+          )
+        } yield resp).getOrElseF(dsl.NotFound())
     }
   }
 }

--- a/modules/restserver/src/main/scala/sharry/restserver/routes/ShareRoutes.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/routes/ShareRoutes.scala
@@ -17,6 +17,9 @@ import org.http4s.*
 import org.http4s.circe.CirceEntityDecoder.*
 import org.http4s.circe.CirceEntityEncoder.*
 import org.http4s.dsl.Http4sDsl
+import org.http4s.headers.*
+import org.http4s.headers.`WWW-Authenticate`
+import org.typelevel.ci.CIString
 
 object ShareRoutes {
 
@@ -97,6 +100,30 @@ object ShareRoutes {
           chunkSize,
           fid
         )
+
+      case req @ GET -> Root / Ident(id) / "zip" =>
+        val pw = SharryPassword(req)
+        val shareId = ShareId.secured(id, token.account)
+        val authChallenge = `WWW-Authenticate`(Challenge("sharry", "sharry"))
+        (for {
+          result <- backend.share.loadZip(shareId, pw)
+          resp <- OptionT.liftF(
+            result.fold(
+              stream =>
+                Ok(stream).map(
+                  _.withHeaders(
+                    `Content-Type`(MediaType.application.zip),
+                    `Content-Disposition`(
+                      "attachment",
+                      Map(CIString("filename") -> s"$id.zip")
+                    )
+                  )
+                ),
+              _ => Forbidden(),
+              _ => Unauthorized(authChallenge)
+            )
+          )
+        } yield resp).getOrElseF(NotFound())
 
       // make it safer by also using the share id
       case DELETE -> Root / Ident(_) / "file" / Ident(fid) =>

--- a/modules/restserver/src/main/scala/sharry/restserver/routes/ShareRoutes.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/routes/ShareRoutes.scala
@@ -18,7 +18,6 @@ import org.http4s.circe.CirceEntityDecoder.*
 import org.http4s.circe.CirceEntityEncoder.*
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.*
-import org.http4s.headers.`WWW-Authenticate`
 import org.typelevel.ci.CIString
 
 object ShareRoutes {
@@ -102,25 +101,17 @@ object ShareRoutes {
         )
 
       case req @ GET -> Root / Ident(id) / "zip" =>
-        val pw = SharryPassword(req)
-        val shareId = ShareId.secured(id, token.account)
-        val authChallenge = `WWW-Authenticate`(Challenge("sharry", "sharry"))
         (for {
-          result <- backend.share.loadZip(shareId, pw)
+          stream <- backend.share.loadZip(ShareId.secured(id, token.account))
           resp <- OptionT.liftF(
-            result.fold(
-              stream =>
-                Ok(stream).map(
-                  _.withHeaders(
-                    `Content-Type`(MediaType.application.zip),
-                    `Content-Disposition`(
-                      "attachment",
-                      Map(CIString("filename") -> s"$id.zip")
-                    )
-                  )
-                ),
-              _ => Forbidden(),
-              _ => Unauthorized(authChallenge)
+            Ok(stream).map(
+              _.withHeaders(
+                `Content-Type`(MediaType.application.zip),
+                `Content-Disposition`(
+                  "attachment",
+                  Map(CIString("filename") -> s"$id.zip")
+                )
+              )
             )
           )
         } yield resp).getOrElseF(NotFound())

--- a/modules/webapp/src/main/elm/Api.elm
+++ b/modules/webapp/src/main/elm/Api.elm
@@ -11,6 +11,8 @@ module Api exposing
     , deleteShare
     , fileOpenUrl
     , fileSecUrl
+    , zipOpenUrl
+    , zipSecUrl
     , findShares
     , getAlias
     , getAliasTemplate
@@ -143,6 +145,16 @@ fileSecUrl flags share fid =
 fileOpenUrl : Flags -> String -> String -> String
 fileOpenUrl flags share fid =
     flags.config.baseUrl ++ "/api/v2/open/share/" ++ share ++ "/file/" ++ fid
+
+
+zipSecUrl : Flags -> String -> String
+zipSecUrl flags share =
+    flags.config.baseUrl ++ "/api/v2/sec/share/" ++ share ++ "/zip"
+
+
+zipOpenUrl : Flags -> String -> String
+zipOpenUrl flags share =
+    flags.config.baseUrl ++ "/api/v2/open/share/" ++ share ++ "/zip"
 
 
 setPassword :

--- a/modules/webapp/src/main/elm/Comp/ShareFileList.elm
+++ b/modules/webapp/src/main/elm/Comp/ShareFileList.elm
@@ -63,6 +63,7 @@ type alias Settings =
     { baseUrl : String
     , viewMode : ViewMode
     , delete : Bool
+    , zipUrl : Maybe String
     }
 
 
@@ -110,12 +111,34 @@ update msg model =
 
 view : Texts -> Settings -> List ShareFile -> Model -> Html Msg
 view texts settings files model =
-    case settings.viewMode of
-        ViewList ->
-            fileTable texts settings model files
+    div []
+        [ zipButton texts settings files
+        , case settings.viewMode of
+            ViewList ->
+                fileTable texts settings model files
 
-        ViewCard ->
-            fileCards texts settings model files
+            ViewCard ->
+                fileCards texts settings model files
+        ]
+
+
+zipButton : Texts -> Settings -> List ShareFile -> Html Msg
+zipButton texts settings files =
+    case ( settings.zipUrl, List.length files > 1 ) of
+        ( Just url, True ) ->
+            div [ class "flex flex-row justify-end mb-2" ]
+                [ a
+                    [ class S.secondaryButton
+                    , href url
+                    , title texts.downloadAllZip
+                    ]
+                    [ i [ class "fa fa-file-archive mr-2" ] []
+                    , text texts.downloadAllZip
+                    ]
+                ]
+
+        _ ->
+            text ""
 
 
 fileCards : Texts -> Settings -> Model -> List ShareFile -> Html Msg

--- a/modules/webapp/src/main/elm/Messages/ShareFileList.elm
+++ b/modules/webapp/src/main/elm/Messages/ShareFileList.elm
@@ -15,6 +15,7 @@ import Messages.YesNoDimmer
 type alias Texts =
     { previewNotSupported : String
     , downloadToDisk : String
+    , downloadAllZip : String
     , viewInBrowser : String
     , deleteFile : String
     , fileIsIncomplete : String
@@ -26,6 +27,7 @@ it : Texts
 it =
     { previewNotSupported = "Anteprima non supportata"
     , downloadToDisk = "Scarica su disco"
+    , downloadAllZip = "Scarica tutto come ZIP"
     , viewInBrowser = "Visualizza nel browser"
     , deleteFile = "Elimina file."
     , fileIsIncomplete = "Il file è incompleto ("
@@ -37,6 +39,7 @@ es : Texts
 es =
     { previewNotSupported = "Vista previa no soportada"
     , downloadToDisk = "Descargar al disco"
+    , downloadAllZip = "Descargar todo como ZIP"
     , viewInBrowser = "Ver en el navegador"
     , deleteFile = "Eliminar el archivo."
     , fileIsIncomplete = "El archivo está incompleto ("
@@ -49,6 +52,7 @@ gb : Texts
 gb =
     { previewNotSupported = "Preview not supported"
     , downloadToDisk = "Download to disk"
+    , downloadAllZip = "Download all as ZIP"
     , viewInBrowser = "View in browser"
     , deleteFile = "Delete the file."
     , fileIsIncomplete = "The file is incomplete ("
@@ -61,6 +65,7 @@ de : Texts
 de =
     { previewNotSupported = "Vorschau nicht unterstützt"
     , downloadToDisk = "Herunterladen"
+    , downloadAllZip = "Alles als ZIP herunterladen"
     , viewInBrowser = "Im Browser ansehen"
     , deleteFile = "Datei löschen."
     , fileIsIncomplete = "Die Datei ist unvollständig ("
@@ -72,6 +77,7 @@ fr : Texts
 fr =
     { previewNotSupported = "Prévisualisation non supportée"
     , downloadToDisk = "Télécharger"
+    , downloadAllZip = "Tout télécharger en ZIP"
     , viewInBrowser = "Prévisualisation"
     , deleteFile = "Supprimer le fichier."
     , fileIsIncomplete = "Le fichier est incomplet ("
@@ -84,6 +90,7 @@ ja : Texts
 ja =
     { previewNotSupported = "プレビュー未対応"
     , downloadToDisk = "ダウンロード"
+    , downloadAllZip = "すべてZIPでダウンロード"
     , viewInBrowser = "ブラウザで表示"
     , deleteFile = "ファイルを削除"
     , fileIsIncomplete = "ファイルが不完全です。 ( "
@@ -95,6 +102,7 @@ cz : Texts
 cz =
     { previewNotSupported = "Náhled není podporován"
     , downloadToDisk = "Stáhnout na disk"
+    , downloadAllZip = "Stáhnout vše jako ZIP"
     , viewInBrowser = "Zobrazit v prohlížeči"
     , deleteFile = "Smazat soubor."
     , fileIsIncomplete = "Soubor nebyl nahrán celý ("

--- a/modules/webapp/src/main/elm/Page/Detail/View.elm
+++ b/modules/webapp/src/main/elm/Page/Detail/View.elm
@@ -110,12 +110,19 @@ descriptionView texts model desc =
 fileList : Texts -> Flags -> Model -> Html Msg
 fileList texts flags model =
     let
+        zipUrl =
+            if flags.config.zipMaxSize > 0 then
+                Just (Api.zipSecUrl flags model.share.id)
+
+            else
+                Nothing
+
         sett =
             Comp.ShareFileList.Settings
                 (Api.fileSecUrl flags model.share.id "")
                 model.fileView
                 True
-                (Just (Api.zipSecUrl flags model.share.id))
+                zipUrl
 
         sorted =
             List.sortBy .filename model.share.files

--- a/modules/webapp/src/main/elm/Page/Detail/View.elm
+++ b/modules/webapp/src/main/elm/Page/Detail/View.elm
@@ -115,6 +115,7 @@ fileList texts flags model =
                 (Api.fileSecUrl flags model.share.id "")
                 model.fileView
                 True
+                (Just (Api.zipSecUrl flags model.share.id))
 
         sorted =
             List.sortBy .filename model.share.files

--- a/modules/webapp/src/main/elm/Page/OpenDetail/View.elm
+++ b/modules/webapp/src/main/elm/Page/OpenDetail/View.elm
@@ -137,6 +137,7 @@ fileList texts flags model =
                 (Api.fileOpenUrl flags (shareId model) "")
                 model.fileView
                 False
+                (Just (Api.zipOpenUrl flags (shareId model)))
 
         sorted =
             List.sortBy .filename model.share.files

--- a/modules/webapp/src/main/elm/Page/OpenDetail/View.elm
+++ b/modules/webapp/src/main/elm/Page/OpenDetail/View.elm
@@ -132,12 +132,19 @@ middleMenu texts model =
 fileList : Texts -> Flags -> Model -> Html Msg
 fileList texts flags model =
     let
+        zipUrl =
+            if flags.config.zipMaxSize > 0 then
+                Just (Api.zipOpenUrl flags (shareId model))
+
+            else
+                Nothing
+
         sett =
             Comp.ShareFileList.Settings
                 (Api.fileOpenUrl flags (shareId model) "")
                 model.fileView
                 False
-                (Just (Api.zipOpenUrl flags (shareId model)))
+                zipUrl
 
         sorted =
             List.sortBy .filename model.share.files


### PR DESCRIPTION
- Adds `GET /open/share/{id}/zip` and `GET /sec/share/{id}/zip` endpoints that stream all share files as a single ZIP archive
- Streaming via `fs2.io.readOutputStream` + `ZipOutputStream` no buffering in memory, works with all storage backends
- Adds "Download all as ZIP" button in the file list (shown only when a share contains more than one file), for both the public and authenticated share views
- OpenAPI spec updated with the new endpoints