### PR TITLE
Display timestamp in user local timezone

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -276,6 +276,7 @@ val restserver = project
   .settings(buildInfoSettings)
   .settings(
     name := "sharry-restserver",
+    scalacOptions += "-Xmax-inlines:64",
     libraryDependencies ++=
       Dependencies.http4s ++
         Dependencies.http4sclient ++

--- a/modules/microsite/docs/doc/configure.md
+++ b/modules/microsite/docs/doc/configure.md
@@ -381,6 +381,39 @@ sharry.restserver.webapp {
 }
 ```
 
+### Timezone
+
+By default, timestamps in the web application are displayed in UTC.
+Sharry can show timestamps in the user's local timezone using the
+following priority order:
+
+1. **User preference** — the user selects a timezone in *Settings*;
+   stored in `localStorage` and used on every subsequent visit.
+2. **Browser auto-detect** — when no user preference is saved, the
+   browser's own timezone is detected automatically (full DST support).
+3. **Server default** — an optional IANA timezone ID set by the
+   administrator. Used as the initial timezone before browser
+   auto-detection resolves.
+4. **UTC** — fallback if nothing is configured (current behavior).
+
+To set a server-side timezone default, add this to your config file:
+
+```
+sharry.restserver.webapp {
+  # IANA timezone ID used as the initial timezone for all users before
+  # browser auto-detect resolves. Overridden by browser auto-detect and
+  # by the user's own preference saved in Settings.
+  # If not set, UTC is used (preserving current behavior).
+  # default-timezone = "Europe/Paris"
+}
+```
+
+Any valid [IANA timezone ID](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+is accepted (e.g. `"Europe/Rome"`, `"America/New_York"`, `"Asia/Tokyo"`).
+This setting is also exposed via the REST API (`GET /api/v2/open/info`)
+as the `defaultTimezone` field of `AppConfig`, which the webapp reads on
+startup.
+
 ### Login Modules
 
 Login modules are used to initially authenticate a user given some

--- a/modules/microsite/docs/doc/webapp.md
+++ b/modules/microsite/docs/doc/webapp.md
@@ -221,3 +221,30 @@ editing its properties is only possible by its creator.
 
 This may be useful to give a group of people access to the same files
 and to make it simpler to share files among registered users.
+
+
+## Settings
+
+Logged-in users can adjust personal preferences from the *Settings*
+page, accessible via the top-right menu.
+
+### Timezone
+
+All timestamps in Sharry (share creation time, expiry dates, etc.) are
+displayed in the user's local timezone. The active timezone is
+determined in the following priority order:
+
+1. **User preference** — set explicitly in *Settings → Timezone*;
+   persisted in `localStorage` and restored on every visit.
+2. **Browser auto-detect** — used automatically when no preference is
+   saved. The browser's own timezone (including DST rules) is used.
+3. **Server default** — an optional IANA timezone ID that an
+   administrator can set in `sharry.restserver.webapp.default-timezone`
+   (see [configuration](configure#timezone)).
+4. **UTC** — fallback if nothing is configured.
+
+To override the timezone, open *Settings* and choose a timezone from
+the searchable dropdown. Selecting the full IANA identifier
+(e.g. `Europe/Rome`, `America/New_York`) ensures correct
+daylight-saving-time handling throughout the year. To revert to
+browser auto-detect, clear the selection in the dropdown.

--- a/modules/restapi/src/main/resources/sharry-openapi.yml
+++ b/modules/restapi/src/main/resources/sharry-openapi.yml
@@ -2076,6 +2076,11 @@ components:
         zipMaxSize:
           type: integer
           format: size
+        defaultTimezone:
+          type: string
+          description: |
+            IANA timezone ID (e.g. "Europe/Paris") used as the initial timezone
+            hint. Overridden by browser auto-detect and user preference.
     OAuthItem:
       description: |
         Information about a configured OAuth provider.

--- a/modules/restapi/src/main/resources/sharry-openapi.yml
+++ b/modules/restapi/src/main/resources/sharry-openapi.yml
@@ -2079,8 +2079,12 @@ components:
         defaultTimezone:
           type: string
           description: |
-            IANA timezone ID (e.g. "Europe/Paris") used as the initial timezone
-            hint. Overridden by browser auto-detect and user preference.
+            Optional IANA timezone ID (e.g. "Europe/Paris", "America/New_York")
+            set by the server administrator as a fallback default. Used as the
+            initial timezone for all users before browser auto-detection resolves.
+            Priority order: user preference (stored in browser) > browser
+            auto-detect > this server default > UTC.
+            If absent or empty, UTC is used (preserving previous behavior).
     OAuthItem:
       description: |
         Information about a configured OAuth provider.

--- a/modules/restserver/src/main/resources/reference.conf
+++ b/modules/restserver/src/main/resources/reference.conf
@@ -131,6 +131,12 @@ sharry.restserver {
     # as utf8 characters. Otherwise the value given here is rendered
     # as is into the template!
     custom-head = ""
+
+    # IANA timezone ID used as the initial timezone for all users before
+    # browser auto-detect resolves. Examples: "Europe/Paris", "America/New_York".
+    # Overridden by browser auto-detect and user preference.
+    # If not set, UTC is used (preserving current behavior).
+    # default-timezone = ""
   }
 
   backend {

--- a/modules/restserver/src/main/scala/sharry/restserver/config/Config.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/config/Config.scala
@@ -96,7 +96,8 @@ object Config {
       defaultValidity: Duration,
       initialTheme: String,
       oauthAutoRedirect: Boolean,
-      customHead: String
+      customHead: String,
+      defaultTimezone: Option[String]
   )
 
   final case class Api(

--- a/modules/restserver/src/main/scala/sharry/restserver/config/ConfigValues.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/config/ConfigValues.scala
@@ -119,6 +119,7 @@ object ConfigValues extends ConfigDecoders:
     val oauthRedirect =
       key("webapp.oauth-auto-redirect", "WEBAPP_OAUTH_AUTO_REDIRECT").as[Boolean]
     val customHead = key("webapp.custom-head", "WEBAPP_CUSTOM_HEAD")
+    val defaultTimezone = key("webapp.default-timezone", "WEBAPP_DEFAULT_TIMEZONE").option
     (
       name,
       icon,
@@ -136,7 +137,8 @@ object ConfigValues extends ConfigDecoders:
       defaultValidity,
       initialTheme,
       oauthRedirect,
-      customHead
+      customHead,
+      defaultTimezone
     ).mapN(Config.Webapp.apply)
   }
 

--- a/modules/restserver/src/main/scala/sharry/restserver/routes/InfoRoutes.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/routes/InfoRoutes.scala
@@ -80,7 +80,8 @@ object InfoRoutes {
       cfg.backend.auth.proxy.enabled,
       cfg.backend.auth.isProxyAuthOnly,
       cfg.backend.auth.isAutoLogin,
-      cfg.backend.share.zipMaxSize
+      cfg.backend.share.zipMaxSize,
+      cfg.webapp.defaultTimezone.filter(_.nonEmpty)
     )
   }
 

--- a/modules/restserver/src/main/templates/index.html
+++ b/modules/restserver/src/main/templates/index.html
@@ -29,11 +29,13 @@
                  var storageTheme = localStorage.getItem('uiTheme');
                  return storageTheme ? storageTheme : initialTheme;
              })();
+         var storedTimezone = localStorage.getItem('timezone');
          var account = storedAccount ? JSON.parse(storedAccount) : null;
          var elmFlags = {
              "account": account,
              "language": lang,
              "uiTheme": theme,
+             "timezone": storedTimezone,
              "config": sharryFlags
          };
         </script>

--- a/modules/webapp/elm.json
+++ b/modules/webapp/elm.json
@@ -18,6 +18,7 @@
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
             "elm-explorations/markdown": "1.0.0",
+            "justinmimbs/timezone-data": "11.1.0",
             "pablohirafuji/elm-qrcode": "4.0.1",
             "ryan-haskell/date-format": "1.0.0"
         },

--- a/modules/webapp/src/main/elm/App/Data.elm
+++ b/modules/webapp/src/main/elm/App/Data.elm
@@ -7,9 +7,12 @@ import Browser.Navigation exposing (Key)
 import Data.Flags exposing (Flags)
 import Data.UiTheme exposing (UiTheme)
 import Data.UploadState exposing (UploadState)
+import Dict
 import Http
 import Language exposing (Language)
 import Page exposing (Page(..))
+import Time
+import TimeZone
 import Page.Account.Data
 import Page.Alias.Data
 import Page.Detail.Data
@@ -31,6 +34,7 @@ type alias Model =
     { flags : Flags
     , key : Key
     , page : Page
+    , zone : Time.Zone
     , navMenuOpen : Bool
     , langMenuOpen : Bool
     , version : VersionInfo
@@ -63,6 +67,7 @@ init key url flags_ =
     { flags = flags
     , key = key
     , page = page
+    , zone = resolveInitialZone flags
     , navMenuOpen = False
     , langMenuOpen = False
     , version = Api.Model.VersionInfo.empty
@@ -86,9 +91,28 @@ init key url flags_ =
     }
 
 
+resolveInitialZone : Flags -> Time.Zone
+resolveInitialZone flags =
+    let
+        fromId id =
+            Dict.get id TimeZone.zones
+                |> Maybe.map (\f -> f ())
+    in
+    case flags.timezone of
+        Just id ->
+            fromId id |> Maybe.withDefault Time.utc
+
+        Nothing ->
+            flags.config.defaultTimezone
+                |> Maybe.andThen fromId
+                |> Maybe.withDefault Time.utc
+
+
 type Msg
     = NavRequest UrlRequest
     | NavChange Url
+    | GotTimeZone Time.Zone
+    | SetTimezone (Maybe String)
     | VersionResp (Result Http.Error VersionInfo)
     | HomeMsg Page.Home.Data.Msg
     | LoginMsg Page.Login.Data.Msg

--- a/modules/webapp/src/main/elm/App/Update.elm
+++ b/modules/webapp/src/main/elm/App/Update.elm
@@ -7,7 +7,12 @@ import Browser.Navigation as Nav
 import Data.Flags
 import Data.InitialView exposing (InitialView)
 import Data.UiTheme
+import Comp.Dropdown
+import Dict
 import Page exposing (Page(..))
+import Task
+import Time
+import TimeZone
 import Page.Account.Data
 import Page.Account.Update
 import Page.Alias.Data
@@ -83,6 +88,48 @@ update msg model =
 
         OpenShareMsg lm ->
             updateOpenShare lm model
+
+        SettingsMsg (Page.Settings.Data.TimezoneDropdownMsg lm) ->
+            let
+                ( newModel, settingsCmd ) =
+                    updateSettings (Page.Settings.Data.TimezoneDropdownMsg lm) model
+            in
+            if Comp.Dropdown.isDropdownChangeMsg lm then
+                let
+                    selectedTz =
+                        Comp.Dropdown.getSelected newModel.settingsModel.timezoneDropdown
+                            |> List.head
+
+                    flags =
+                        newModel.flags
+
+                    newFlags =
+                        { flags | timezone = selectedTz }
+
+                    newZone =
+                        case selectedTz of
+                            Just id ->
+                                Dict.get id TimeZone.zones
+                                    |> Maybe.map (\f -> f ())
+                                    |> Maybe.withDefault newModel.zone
+
+                            Nothing ->
+                                newModel.zone
+
+                    detectCmd =
+                        case selectedTz of
+                            Nothing ->
+                                Task.perform GotTimeZone Time.here
+
+                            Just _ ->
+                                Cmd.none
+                in
+                ( { newModel | zone = newZone, flags = newFlags }
+                , Cmd.batch [ settingsCmd, Ports.setTimezone selectedTz, detectCmd ]
+                )
+
+            else
+                ( newModel, settingsCmd )
 
         SettingsMsg lm ->
             updateSettings lm model
@@ -253,6 +300,39 @@ update msg model =
         SetLanguage lang ->
             ( { model | langMenuOpen = False }
             , Ports.setLang lang
+            )
+
+        GotTimeZone zone ->
+            ( { model | zone = zone }, Cmd.none )
+
+        SetTimezone maybeId ->
+            let
+                newZone =
+                    case maybeId of
+                        Just id ->
+                            Dict.get id TimeZone.zones
+                                |> Maybe.map (\f -> f ())
+                                |> Maybe.withDefault model.zone
+
+                        Nothing ->
+                            model.zone
+
+                detectCmd =
+                    case maybeId of
+                        Nothing ->
+                            Task.perform GotTimeZone Time.here
+
+                        Just _ ->
+                            Cmd.none
+
+                flags =
+                    model.flags
+
+                newFlags =
+                    { flags | timezone = maybeId }
+            in
+            ( { model | zone = newZone, flags = newFlags }
+            , Cmd.batch [ Ports.setTimezone maybeId, detectCmd ]
             )
 
 

--- a/modules/webapp/src/main/elm/App/View.elm
+++ b/modules/webapp/src/main/elm/App/View.elm
@@ -32,7 +32,7 @@ view : Model -> Html Msg
 view model =
     let
         texts =
-            Messages.fromFlags model.flags
+            Messages.fromFlags model.flags |> Messages.withZone model.zone
     in
     div
         [ id "main"
@@ -346,7 +346,7 @@ viewDetail _ texts model =
 
 viewSettings : Messages -> Model -> Html Msg
 viewSettings texts model =
-    Html.map SettingsMsg (Page.Settings.View.view texts.settings model.settingsModel)
+    Html.map SettingsMsg (Page.Settings.View.view texts.settings model.flags.timezone model.settingsModel)
 
 
 viewAlias : Maybe String -> Messages -> Model -> Html Msg

--- a/modules/webapp/src/main/elm/Data/Flags.elm
+++ b/modules/webapp/src/main/elm/Data/Flags.elm
@@ -13,6 +13,7 @@ type alias Flags =
     { account : Maybe AuthResult
     , language : Maybe String
     , uiTheme : Maybe String
+    , timezone : Maybe String
     , config : AppConfig
     }
 

--- a/modules/webapp/src/main/elm/Main.elm
+++ b/modules/webapp/src/main/elm/Main.elm
@@ -13,6 +13,8 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import Page exposing (Page(..))
 import Ports
+import Task
+import Time
 import Url exposing (Url)
 
 
@@ -65,6 +67,12 @@ init flags url key =
         [ cmd
         , Api.versionInfo flags VersionResp
         , sessionCheck
+        , case flags.timezone of
+            Nothing ->
+                Task.perform GotTimeZone Time.here
+
+            Just _ ->
+                Cmd.none
         ]
     )
 

--- a/modules/webapp/src/main/elm/Messages.elm
+++ b/modules/webapp/src/main/elm/Messages.elm
@@ -3,12 +3,15 @@ module Messages exposing
     , fromFlags
     , get
     , toIso2
+    , withZone
     )
 
 import Data.Flags exposing (Flags)
 import Language exposing (Language(..), allLanguages)
 import Messages.AccountPage
+import Messages.AccountTable
 import Messages.AliasPage
+import Messages.AliasTable
 import Messages.App
 import Messages.DetailPage
 import Messages.HomePage
@@ -17,7 +20,9 @@ import Messages.NewInvitePage
 import Messages.RegisterPage
 import Messages.SettingsPage
 import Messages.SharePage
+import Messages.ShareTable
 import Messages.UploadPage
+import Time
 
 
 {-| The messages record contains all strings used in the application.
@@ -108,6 +113,32 @@ fromFlags flags =
     fromIso2 iso
         |> get
 
+
+
+{-| Apply a time zone to all date/time display functions in the messages.
+Called in App.View after building messages from flags.
+-}
+withZone : Time.Zone -> Messages -> Messages
+withZone zone msgs =
+    let
+        lang =
+            msgs.lang
+
+        account =
+            msgs.account
+
+        aliasPage =
+            msgs.aliasPage
+
+        upload =
+            msgs.upload
+    in
+    { msgs
+        | account = { account | accountTable = Messages.AccountTable.applyZone zone lang account.accountTable }
+        , aliasPage = { aliasPage | aliasTable = Messages.AliasTable.applyZone zone lang aliasPage.aliasTable }
+        , upload = { upload | shareTable = Messages.ShareTable.applyZone zone lang upload.shareTable }
+        , detail = Messages.DetailPage.applyZone zone lang msgs.detail
+    }
 
 
 --- Messages Definitions

--- a/modules/webapp/src/main/elm/Messages/AccountTable.elm
+++ b/modules/webapp/src/main/elm/Messages/AccountTable.elm
@@ -1,5 +1,6 @@
 module Messages.AccountTable exposing
     ( Texts
+    , applyZone
     , de
     , fr
     , gb
@@ -9,8 +10,9 @@ module Messages.AccountTable exposing
     , it
     )
 
-import Language
+import Language exposing (Language)
 import Messages.DateFormat exposing (formatDateTime)
+import Time
 
 
 
@@ -41,7 +43,7 @@ it =
     , lastLogin = "Ultimo Accesso"
     , created = "Creazione"
     , edit = "Modifica"
-    , dateTime = formatDateTime Language.Italian
+    , dateTime = formatDateTime Language.Italian Time.utc
     }
 
 es : Texts
@@ -55,7 +57,7 @@ es =
     , lastLogin = "Último inicio de sesión"
     , created = "Creado"
     , edit = "Editar"
-    , dateTime = formatDateTime Language.Spanish
+    , dateTime = formatDateTime Language.Spanish Time.utc
     }
 
 
@@ -70,7 +72,7 @@ gb =
     , lastLogin = "Last Login"
     , created = "Created"
     , edit = "Edit"
-    , dateTime = formatDateTime Language.English
+    , dateTime = formatDateTime Language.English Time.utc
     }
 
 
@@ -85,7 +87,7 @@ de =
     , lastLogin = "Letzte Anmeldung"
     , created = "Erstellt"
     , edit = "Editieren"
-    , dateTime = formatDateTime Language.German
+    , dateTime = formatDateTime Language.German Time.utc
     }
 
 
@@ -100,7 +102,7 @@ fr =
     , lastLogin = "Dernière connexion"
     , created = "Créé"
     , edit = "Éditer"
-    , dateTime = formatDateTime Language.French
+    , dateTime = formatDateTime Language.French Time.utc
     }
 
 
@@ -115,7 +117,7 @@ ja =
     , lastLogin = "最終ログイン"
     , created = "作成日時"
     , edit = "編集"
-    , dateTime = formatDateTime Language.Japanese
+    , dateTime = formatDateTime Language.Japanese Time.utc
     }
 
 cz : Texts
@@ -129,5 +131,10 @@ cz  =
     , lastLogin = "Poslední přihlášení"
     , created = "Založeno"
     , edit = "Editovat"
-    , dateTime = formatDateTime Language.Czech
+    , dateTime = formatDateTime Language.Czech Time.utc
     }
+
+
+applyZone : Time.Zone -> Language -> Texts -> Texts
+applyZone zone lang texts =
+    { texts | dateTime = formatDateTime lang zone }

--- a/modules/webapp/src/main/elm/Messages/AliasTable.elm
+++ b/modules/webapp/src/main/elm/Messages/AliasTable.elm
@@ -1,5 +1,6 @@
 module Messages.AliasTable exposing
     ( Texts
+    , applyZone
     , de
     , fr
     , gb
@@ -9,9 +10,10 @@ module Messages.AliasTable exposing
     , it
     )
 
-import Language
+import Language exposing (Language)
 import Messages.DateFormat
 import Messages.ValidityField
+import Time
 
 
 type alias Texts =
@@ -36,7 +38,7 @@ it =
     , show = "Visualizza"
     , owner = "Proprietario"
     , validityField = Messages.ValidityField.it
-    , dateTime = Messages.DateFormat.formatDateTime Language.Italian
+    , dateTime = Messages.DateFormat.formatDateTime Language.Italian Time.utc
     }
 
 es : Texts
@@ -49,7 +51,7 @@ es =
     , show = "Mostrar"
     , owner = "Propietario"
     , validityField = Messages.ValidityField.es
-    , dateTime = Messages.DateFormat.formatDateTime Language.Spanish
+    , dateTime = Messages.DateFormat.formatDateTime Language.Spanish Time.utc
     }
 
 
@@ -63,7 +65,7 @@ gb =
     , show = "Show"
     , owner = "Owner"
     , validityField = Messages.ValidityField.gb
-    , dateTime = Messages.DateFormat.formatDateTime Language.English
+    , dateTime = Messages.DateFormat.formatDateTime Language.English Time.utc
     }
 
 
@@ -77,7 +79,7 @@ de =
     , show = "Anzeigen"
     , owner = "Eigentümer"
     , validityField = Messages.ValidityField.de
-    , dateTime = Messages.DateFormat.formatDateTime Language.German
+    , dateTime = Messages.DateFormat.formatDateTime Language.German Time.utc
     }
 
 
@@ -91,7 +93,7 @@ fr =
     , show = "Show"
     , owner = "Owner"
     , validityField = Messages.ValidityField.fr
-    , dateTime = Messages.DateFormat.formatDateTime Language.French
+    , dateTime = Messages.DateFormat.formatDateTime Language.French Time.utc
     }
 
 
@@ -105,7 +107,7 @@ ja =
     , show = "表示"
     , owner = "所有者"
     , validityField = Messages.ValidityField.ja
-    , dateTime = Messages.DateFormat.formatDateTime Language.Japanese
+    , dateTime = Messages.DateFormat.formatDateTime Language.Japanese Time.utc
     }
 
 cz : Texts
@@ -118,5 +120,10 @@ cz =
     , show = "Zobrazit"
     , owner = "Vlastník"
     , validityField = Messages.ValidityField.cz
-    , dateTime = Messages.DateFormat.formatDateTime Language.Czech
+    , dateTime = Messages.DateFormat.formatDateTime Language.Czech Time.utc
     }
+
+
+applyZone : Time.Zone -> Language -> Texts -> Texts
+applyZone zone lang texts =
+    { texts | dateTime = Messages.DateFormat.formatDateTime lang zone }

--- a/modules/webapp/src/main/elm/Messages/DateFormat.elm
+++ b/modules/webapp/src/main/elm/Messages/DateFormat.elm
@@ -40,8 +40,8 @@ get lang =
         Italian ->
             it
 
-formatDateTime : Language -> Int -> String
-formatDateTime lang millis =
+formatDateTime : Language -> Time.Zone -> Int -> String
+formatDateTime lang zone millis =
     let
         msg =
             get lang
@@ -49,7 +49,7 @@ formatDateTime lang millis =
         fmt =
             DateFormat.formatWithLanguage msg.lang msg.format
     in
-    fmt Time.utc (Time.millisToPosix millis)
+    fmt zone (Time.millisToPosix millis)
 
 
 

--- a/modules/webapp/src/main/elm/Messages/DetailPage.elm
+++ b/modules/webapp/src/main/elm/Messages/DetailPage.elm
@@ -1,5 +1,6 @@
 module Messages.DetailPage exposing
     ( Texts
+    , applyZone
     , de
     , fr
     , gb
@@ -10,8 +11,9 @@ module Messages.DetailPage exposing
     )
 
 import Data.InitialView exposing (InitialView)
-import Language
+import Language exposing (Language)
 import Messages.DateFormat
+import Time
 import Messages.Dropzone2
 import Messages.MailSend
 import Messages.MarkdownInput
@@ -139,7 +141,7 @@ it =
     , passwordRequired = "Password necessaria"
     , passwordInvalid = "Password non valida"
     , or = "Oppure"
-    , dateTime = Messages.DateFormat.formatDateTime Language.Italian
+    , dateTime = Messages.DateFormat.formatDateTime Language.Italian Time.utc
     , initialViewLabel =
         \iv ->
             case iv of
@@ -216,7 +218,7 @@ es =
     , passwordRequired = "Contraseña requerida"
     , passwordInvalid = "Contraseña inválida"
     , or = "O"
-    , dateTime = Messages.DateFormat.formatDateTime Language.Spanish
+    , dateTime = Messages.DateFormat.formatDateTime Language.Spanish Time.utc
     , initialViewLabel =
         \iv ->
             case iv of
@@ -294,7 +296,7 @@ gb =
     , passwordRequired = "Password required"
     , passwordInvalid = "Password invalid"
     , or = "Or"
-    , dateTime = Messages.DateFormat.formatDateTime Language.English
+    , dateTime = Messages.DateFormat.formatDateTime Language.English Time.utc
     , initialViewLabel =
         \iv ->
             case iv of
@@ -373,7 +375,7 @@ de =
     , passwordRequired = "Passwort erforderlich"
     , passwordInvalid = "Passwort ungültig"
     , or = "Oder"
-    , dateTime = Messages.DateFormat.formatDateTime Language.German
+    , dateTime = Messages.DateFormat.formatDateTime Language.German Time.utc
     , initialViewLabel =
         \iv ->
             case iv of
@@ -455,7 +457,7 @@ fr =
     , passwordRequired = "Mot de passe requis"
     , passwordInvalid = "Mot de passe invalide"
     , or = "Ou"
-    , dateTime = Messages.DateFormat.formatDateTime Language.French
+    , dateTime = Messages.DateFormat.formatDateTime Language.French Time.utc
     , initialViewLabel =
         \iv ->
             case iv of
@@ -531,7 +533,7 @@ ja =
     , passwordRequired = "要パスワード"
     , passwordInvalid = "パスワードが無効"
     , or = "または"
-    , dateTime = Messages.DateFormat.formatDateTime Language.Japanese
+    , dateTime = Messages.DateFormat.formatDateTime Language.Japanese Time.utc
     , initialViewLabel =
         \iv ->
             case iv of
@@ -609,7 +611,7 @@ cz =
     , passwordRequired = "Heslo vyžadováno"
     , passwordInvalid = "Chybějící heslo"
     , or = "Nebo"
-    , dateTime = Messages.DateFormat.formatDateTime Language.Czech
+    , dateTime = Messages.DateFormat.formatDateTime Language.Czech Time.utc
     , initialViewLabel =
         \iv ->
             case iv of
@@ -623,3 +625,8 @@ cz =
                     "Náhled"
     , initialViewField = "Výchozí zobrazení: "
     }
+
+
+applyZone : Time.Zone -> Language -> Texts -> Texts
+applyZone zone lang texts =
+    { texts | dateTime = Messages.DateFormat.formatDateTime lang zone }

--- a/modules/webapp/src/main/elm/Messages/SettingsPage.elm
+++ b/modules/webapp/src/main/elm/Messages/SettingsPage.elm
@@ -21,6 +21,12 @@ type alias Texts =
     , currentPassword : String
     , newPassword : String
     , newPasswordRepeat : String
+    , timezoneHeader : String
+    , timezoneAutoLabel : String
+    , timezoneAutoHint : String
+    , timezoneManualLabel : String
+    , timezoneResetButton : String
+    , timezoneInputPlaceholder : String
     }
 
 it : Texts
@@ -35,6 +41,12 @@ it =
     , currentPassword = "Password Attuale"
     , newPassword = "Nuova Password"
     , newPasswordRepeat = "Nuova Password (Ripeti)"
+    , timezoneHeader = "Fuso Orario"
+    , timezoneAutoLabel = "Automatico (dal browser)"
+    , timezoneAutoHint = "Il fuso orario viene rilevato automaticamente dal browser."
+    , timezoneManualLabel = "Fuso orario attuale:"
+    , timezoneResetButton = "Ripristina automatico"
+    , timezoneInputPlaceholder = "Es. Europe/Rome"
     }
 
 es : Texts
@@ -49,6 +61,12 @@ es =
     , currentPassword = "Contraseña Actual"
     , newPassword = "Nueva Contraseña"
     , newPasswordRepeat = "Nueva Contraseña (Repetir)"
+    , timezoneHeader = "Zona Horaria"
+    , timezoneAutoLabel = "Automático (desde el navegador)"
+    , timezoneAutoHint = "La zona horaria se detecta automáticamente desde el navegador."
+    , timezoneManualLabel = "Zona horaria actual:"
+    , timezoneResetButton = "Restablecer automático"
+    , timezoneInputPlaceholder = "Ej. Europe/Madrid"
     }
 
 
@@ -64,6 +82,12 @@ gb =
     , currentPassword = "Current Password"
     , newPassword = "New Password"
     , newPasswordRepeat = "New Password (Repeat)"
+    , timezoneHeader = "Timezone"
+    , timezoneAutoLabel = "Automatic (from browser)"
+    , timezoneAutoHint = "The timezone is automatically detected from your browser."
+    , timezoneManualLabel = "Current timezone:"
+    , timezoneResetButton = "Reset to automatic"
+    , timezoneInputPlaceholder = "E.g. Europe/London"
     }
 
 
@@ -79,6 +103,12 @@ de =
     , currentPassword = "Aktuelles Passwort"
     , newPassword = "Neues Passwort"
     , newPasswordRepeat = "Neues Passwort (Wiederholung)"
+    , timezoneHeader = "Zeitzone"
+    , timezoneAutoLabel = "Automatisch (vom Browser)"
+    , timezoneAutoHint = "Die Zeitzone wird automatisch vom Browser erkannt."
+    , timezoneManualLabel = "Aktuelle Zeitzone:"
+    , timezoneResetButton = "Auf automatisch zurücksetzen"
+    , timezoneInputPlaceholder = "Z.B. Europe/Berlin"
     }
 
 fr : Texts
@@ -93,6 +123,12 @@ fr =
     , currentPassword = "Mot de passe actuel"
     , newPassword = "Nouveau mot de passe"
     , newPasswordRepeat = "Nouveau mot de passe (bis)"
+    , timezoneHeader = "Fuseau horaire"
+    , timezoneAutoLabel = "Automatique (depuis le navigateur)"
+    , timezoneAutoHint = "Le fuseau horaire est automatiquement détecté depuis votre navigateur."
+    , timezoneManualLabel = "Fuseau horaire actuel :"
+    , timezoneResetButton = "Revenir à l'automatique"
+    , timezoneInputPlaceholder = "Ex. Europe/Paris"
     }
 
 
@@ -108,6 +144,12 @@ ja =
     , currentPassword = "現在のパスワード"
     , newPassword = "新しいパスワード"
     , newPasswordRepeat = "新しいパスワード ( 確認 )"
+    , timezoneHeader = "タイムゾーン"
+    , timezoneAutoLabel = "自動（ブラウザから）"
+    , timezoneAutoHint = "タイムゾーンはブラウザから自動的に検出されます。"
+    , timezoneManualLabel = "現在のタイムゾーン："
+    , timezoneResetButton = "自動に戻す"
+    , timezoneInputPlaceholder = "例: Asia/Tokyo"
     }
 
 
@@ -123,4 +165,10 @@ cz =
     , currentPassword = "Stávající heslo"
     , newPassword = "Nové heslo"
     , newPasswordRepeat = "Nové heslo (znovu)"
+    , timezoneHeader = "Časové pásmo"
+    , timezoneAutoLabel = "Automaticky (z prohlížeče)"
+    , timezoneAutoHint = "Časové pásmo je automaticky detekováno z prohlížeče."
+    , timezoneManualLabel = "Aktuální časové pásmo:"
+    , timezoneResetButton = "Obnovit automatické"
+    , timezoneInputPlaceholder = "Např. Europe/Prague"
     }

--- a/modules/webapp/src/main/elm/Messages/ShareTable.elm
+++ b/modules/webapp/src/main/elm/Messages/ShareTable.elm
@@ -1,5 +1,6 @@
 module Messages.ShareTable exposing
     ( Texts
+    , applyZone
     , de
     , fr
     , gb
@@ -9,8 +10,9 @@ module Messages.ShareTable exposing
     , it
     )
 
-import Language
+import Language exposing (Language)
 import Messages.DateFormat
+import Time
 
 
 type alias Texts =
@@ -35,7 +37,7 @@ it =
     , size = "Dimensione"
     , created = "Creazione"
     , open = "Apri"
-    , dateTime = Messages.DateFormat.formatDateTime Language.Italian
+    , dateTime = Messages.DateFormat.formatDateTime Language.Italian Time.utc
     }
 
 es : Texts
@@ -48,7 +50,7 @@ es =
     , size = "Tamaño"
     , created = "Creado"
     , open = "Abrir"
-    , dateTime = Messages.DateFormat.formatDateTime Language.Spanish
+    , dateTime = Messages.DateFormat.formatDateTime Language.Spanish Time.utc
     }
 
 
@@ -62,7 +64,7 @@ gb =
     , size = "Size"
     , created = "Created"
     , open = "Open"
-    , dateTime = Messages.DateFormat.formatDateTime Language.English
+    , dateTime = Messages.DateFormat.formatDateTime Language.English Time.utc
     }
 
 
@@ -76,7 +78,7 @@ de =
     , size = "Größe"
     , created = "Erstellt"
     , open = "Öffnen"
-    , dateTime = Messages.DateFormat.formatDateTime Language.German
+    , dateTime = Messages.DateFormat.formatDateTime Language.German Time.utc
     }
 
 
@@ -90,7 +92,7 @@ fr =
     , size = "Taille"
     , created = "Créé"
     , open = "Ouvrir"
-    , dateTime = Messages.DateFormat.formatDateTime Language.French
+    , dateTime = Messages.DateFormat.formatDateTime Language.French Time.utc
     }
 
 
@@ -104,7 +106,7 @@ ja =
     , size = "サイズ"
     , created = "作成日時"
     , open = "開く"
-    , dateTime = Messages.DateFormat.formatDateTime Language.Japanese
+    , dateTime = Messages.DateFormat.formatDateTime Language.Japanese Time.utc
     }
 
 
@@ -118,6 +120,11 @@ cz =
     , size = "Velikost"
     , created = "Vytvořeno"
     , open = "Otevřít"
-    , dateTime = Messages.DateFormat.formatDateTime Language.Czech
+    , dateTime = Messages.DateFormat.formatDateTime Language.Czech Time.utc
     }
+
+
+applyZone : Time.Zone -> Language -> Texts -> Texts
+applyZone zone lang texts =
+    { texts | dateTime = Messages.DateFormat.formatDateTime lang zone }
 

--- a/modules/webapp/src/main/elm/Page/Settings/Data.elm
+++ b/modules/webapp/src/main/elm/Page/Settings/Data.elm
@@ -7,6 +7,7 @@ module Page.Settings.Data exposing
 
 import Api.Model.BasicResult exposing (BasicResult)
 import Api.Model.EmailInfo exposing (EmailInfo)
+import Comp.Dropdown
 import Comp.PasswordInput
 import Http
 
@@ -28,6 +29,7 @@ type alias Model =
     , currentEmail : Maybe String
     , banner : Maybe Banner
     , passwordAvailable : Maybe Bool
+    , timezoneDropdown : Comp.Dropdown.Model String
     }
 
 
@@ -43,6 +45,7 @@ emptyModel =
     , currentEmail = Nothing
     , banner = Nothing
     , passwordAvailable = Nothing
+    , timezoneDropdown = Comp.Dropdown.makeSingle
     }
 
 
@@ -57,3 +60,4 @@ type Msg
     | GetEmailResp (Result Http.Error EmailInfo)
     | SaveResp (Result Http.Error BasicResult)
     | CheckPassResp (Result Http.Error BasicResult)
+    | TimezoneDropdownMsg (Comp.Dropdown.Msg String)

--- a/modules/webapp/src/main/elm/Page/Settings/Update.elm
+++ b/modules/webapp/src/main/elm/Page/Settings/Update.elm
@@ -2,9 +2,12 @@ module Page.Settings.Update exposing (update)
 
 import Api
 import Api.Model.PasswordChange exposing (PasswordChange)
+import Comp.Dropdown
 import Comp.PasswordInput
 import Data.Flags exposing (Flags)
+import Dict
 import Page.Settings.Data exposing (Banner, Model, Msg(..))
+import TimeZone
 import Util.Http
 import Util.Maybe
 
@@ -13,7 +16,17 @@ update : Flags -> Msg -> Model -> ( Model, Cmd Msg )
 update flags msg model =
     case msg of
         Init ->
-            ( { model | banner = Nothing }
+            let
+                allZones =
+                    Dict.keys TimeZone.zones |> List.sort
+
+                dropdownModel =
+                    Comp.Dropdown.makeSingleList
+                        { options = allZones
+                        , selected = flags.timezone
+                        }
+            in
+            ( { model | banner = Nothing, timezoneDropdown = dropdownModel }
             , Cmd.batch
                 [ Api.getEmail flags GetEmailResp
                 , Api.checkPassword flags CheckPassResp
@@ -147,3 +160,10 @@ update flags msg model =
                 ( { model | banner = Just <| Banner False "Passwords don't match." }
                 , Cmd.none
                 )
+
+        TimezoneDropdownMsg lm ->
+            let
+                ( dm, _ ) =
+                    Comp.Dropdown.update lm model.timezoneDropdown
+            in
+            ( { model | timezoneDropdown = dm }, Cmd.none )

--- a/modules/webapp/src/main/elm/Page/Settings/View.elm
+++ b/modules/webapp/src/main/elm/Page/Settings/View.elm
@@ -1,8 +1,10 @@
 module Page.Settings.View exposing (view)
 
 import Comp.Basic as B
+import Comp.Dropdown
 import Comp.MenuBar as MB
 import Comp.PasswordInput
+import Data.DropdownStyle as DS
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onInput)
@@ -11,8 +13,8 @@ import Page.Settings.Data exposing (Model, Msg(..))
 import Styles as S
 
 
-view : Texts -> Model -> Html Msg
-view texts model =
+view : Texts -> Maybe String -> Model -> Html Msg
+view texts currentTimezone model =
     div
         [ class S.content
         , class "flex flex-col"
@@ -22,8 +24,33 @@ view texts model =
             , text texts.settingsTitle
             ]
         , banner model
+        , timezoneForm texts currentTimezone model
         , emailForm texts model
         , changePasswordForm texts model
+        ]
+
+
+timezoneForm : Texts -> Maybe String -> Model -> Html Msg
+timezoneForm texts currentTimezone model =
+    div [ class "flex flex-col mb-4" ]
+        [ h2 [ class S.header2 ]
+            [ text texts.timezoneHeader ]
+        , Html.map TimezoneDropdownMsg
+            (Comp.Dropdown.viewSingle2
+                { makeOption = \s -> { text = s, additional = "" }
+                , placeholder = texts.timezoneInputPlaceholder
+                , labelColor = \_ -> ""
+                , style = DS.mainStyle
+                }
+                model.timezoneDropdown
+            )
+        , case currentTimezone of
+            Nothing ->
+                p [ class "text-sm opacity-70 mt-1" ]
+                    [ text texts.timezoneAutoHint ]
+
+            Just _ ->
+                text ""
         ]
 
 

--- a/modules/webapp/src/main/elm/Ports.elm
+++ b/modules/webapp/src/main/elm/Ports.elm
@@ -68,3 +68,9 @@ port internalSetUiTheme : String -> Cmd msg
 setUiTheme : UiTheme -> Cmd msg
 setUiTheme theme =
     internalSetUiTheme (Data.UiTheme.toString theme)
+
+
+port setTimezone : Maybe String -> Cmd msg
+
+
+port receiveTimezone : (Maybe String -> msg) -> Sub msg

--- a/modules/webapp/src/main/webjar/sharry.js
+++ b/modules/webapp/src/main/webjar/sharry.js
@@ -190,5 +190,13 @@ elmApp.ports.internalSetUiTheme.subscribe(function(themeName) {
     }
 });
 
+elmApp.ports.setTimezone.subscribe(function(id) {
+    if (id === null || id === undefined) {
+        localStorage.removeItem("timezone");
+    } else {
+        localStorage.setItem("timezone", id);
+    }
+});
+
 
 applyUiTheme(theme);


### PR DESCRIPTION
This PR handles #634 and #1523. 

- All timestamps in the webapp (share creation, expiry, etc..) are now displayed in the user local timezone instead of always using UTC.
- Timezone is resolved with the following priority:
  - **User preference** — IANA ID selected in Settings, persisted in `localStorage` and restored on page load.
  - **Browser auto detect** — `Time.here` is called on startup when no preference is saved. Provides full DST support automatically.
  - **Server default** — optional `sharry.restserver.webapp.default-timezone` config value (IANA string) set by the admin.
  - **UTC** — fallback, preserves current behavior when nothing is configured.

## New external dependency: `justinmimbs/timezone-data` 11.1.0

Elm `Time.Zone` type is opaque, there is no built in API to handle a DST aware zone from IANA string. `Time.here` gives the browser timezone but only at startup, and cannot be used to display times in an arbitrary zone.

`justinmimbs/timezone-data` embeds the full IANA timezone database directly in the compiled Elm bundle, exposing:
```elm
TimeZone.zones : Dict String (() -> Time.Zone)
```

This is the only approach that provides correct DST formatting for any selected IANA timezone (e.g. Europe/Rome switches between UTC+1 and UTC+2 across the year). 
No runtime fetch, no JS interop beyond the already existing port for localStorage.

The package is published on package.elm-lang.org and is the standard community solution for this problem.

## Changes

- build.sbt: added `-Xmax-inlines:64` to restserver scalacOptions (deriveValueConverter[AppConfig] with 29 fields exceeded Scala 3's default inline limit of 32)
- elm.json: added `justinmimbs/timezone-data: 11.1.0`
- Messages/DateFormat.elm: `formatDateTime` now accepts a Time.Zone parameter instead of hardcoding `Time.utc`
- App/Data.elm, App/Update.elm, App/View.elm: `Time.Zone` added to the root model, `Time.here` dispatched on startup, `GotTimeZone` and `SetTimezone` messages added
- Ports.elm, sharry.js: setTimezone port persist the IANA ID to localStorage, index.html reads it into Elm flags on load
- Page/Settings: timezone section added, searchable IANA dropdown (Comp.Dropdown) backed by `TimeZone.zones`, deselecting clear the preference and revert to browser auto detect
- Config.scala, ConfigValues.scala, InfoRoutes.scala, reference.conf: optional `webapp.default-timezone` server config option; exposed via GET `/api/v2/open/info` as `defaultTimezone`
- sharry-openapi.yml, configure.md, webapp.md: documentation for the new config option and client side behavior.

# Note on webapp.default-timezone (server config option)
The `webapp.default-timezone` option in the current implementation only acts as the initial zone before `Time.here` resolves on startup.
Because `Time.here` always succeeds in a browser, the server default is immediately overridden by browser auto detection.
This means priority 3 is unreachable at runtime, I was unsure of the intended semantics. How would you like to proceed?

- Keep the current implementation: browser auto detect always wins over the server default
- Server default skips auto detect: if `default-timezone` is set, use it and skip `Time.here` (Useful if the admin want to force a specific zone for al lthe users)
- Remove the option: simplify the feature and just keep the priority 1, 2, 4
