### PR TITLE
Force share password via server config

### DIFF
--- a/modules/backend/src/main/scala/sharry/backend/share/OShare.scala
+++ b/modules/backend/src/main/scala/sharry/backend/share/OShare.scala
@@ -159,7 +159,9 @@ object OShare {
             accId.alias,
             data.copy(password = data.password.map(PasswordCrypt.crypt))
           )
-          valid = UploadResult(share).checkValidity(cfg.maxValidity)(_.validity)
+          valid = UploadResult(share)
+            .checkValidity(cfg.maxValidity)(_.validity)
+            .checkPasswordRequired(cfg.requireSharePassword)(_.password)
           _ <- valid.mapF(r => store.transact(RShare.insert(r)))
           _ <- logger.debug(s"Result creating share for '${accId.id.id}': $valid")
         } yield valid.map(_.id)

--- a/modules/backend/src/main/scala/sharry/backend/share/ShareConfig.scala
+++ b/modules/backend/src/main/scala/sharry/backend/share/ShareConfig.scala
@@ -8,5 +8,6 @@ case class ShareConfig(
     maxSize: ByteSize,
     maxValidity: Duration,
     databaseDomainChecks: Seq[DomainCheckConfig],
-    zipMaxSize: ByteSize
+    zipMaxSize: ByteSize,
+    requireSharePassword: Boolean
 )

--- a/modules/backend/src/main/scala/sharry/backend/share/UploadResult.scala
+++ b/modules/backend/src/main/scala/sharry/backend/share/UploadResult.scala
@@ -32,6 +32,10 @@ sealed trait UploadResult[+A] {
   def checkValidity(max: Duration)(f: A => Duration): UploadResult[A] =
     if (toOption.forall(e => f(e) <= max)) this
     else UploadResult.validityExceeded(max)
+
+  def checkPasswordRequired(required: Boolean)(f: A => Option[?]): UploadResult[A] =
+    if (!required || toOption.forall(e => f(e).isDefined)) this
+    else UploadResult.PermanentError("A password is required for this share.")
 }
 
 object UploadResult {

--- a/modules/microsite/docs/doc/configure.md
+++ b/modules/microsite/docs/doc/configure.md
@@ -184,6 +184,35 @@ even when the full share exceeds the limit.
 The value cannot exceed `max-size`; if it does, it is silently capped
 at startup.
 
+### Require Share Password
+
+The `require-share-password` flag forces authenticated users to set a
+password whenever they create a share.
+
+```
+sharry.restserver.backend.share {
+  # When true, authenticated users must provide a password when
+  # creating a share. The server enforces this on every upload path;
+  # removing the password from an existing share is also blocked.
+  # Defaults to false.
+  require-share-password = false
+}
+```
+
+When enabled:
+
+- The password field is marked as required in the share creation form.
+- Submitting the form without a password shows a localised error
+  message and the share is not created.
+- `DELETE /api/v2/sec/share/{id}/password` returns an error instead of
+  removing the password.
+- The restriction is enforced server-side on both upload endpoints
+  (`POST /api/v2/sec/upload` and `POST /api/v2/sec/upload/new`), so it
+  cannot be bypassed by calling the API directly.
+
+This setting does not affect alias uploads, which use a separate
+authentication flow.
+
 ### Files
 
 By default, the files are also stored in the configured database. This

--- a/modules/microsite/docs/doc/webapp.md
+++ b/modules/microsite/docs/doc/webapp.md
@@ -112,6 +112,12 @@ You can share the URL using one channel (maybe e-mail) and the
 password using another channel. A person must have both things in
 order to see the files.
 
+If the administrator has enabled `require-share-password` in the
+server configuration, setting a password is mandatory. The password
+field is marked as required and the share cannot be created without
+one. An existing password cannot be removed while this setting is
+active. See [configure](configure.md) for details.
+
 
 ### Maximum Views
 

--- a/modules/restapi/src/main/resources/sharry-openapi.yml
+++ b/modules/restapi/src/main/resources/sharry-openapi.yml
@@ -2034,6 +2034,7 @@ components:
         - proxyOnly
         - hideLoginForm
         - zipMaxSize
+        - sharePasswordRequired
       properties:
         appName:
           type: string
@@ -2119,6 +2120,8 @@ components:
             Priority order: user preference (stored in browser) > browser
             auto-detect > this server default > UTC.
             If absent or empty, UTC is used (preserving previous behavior).
+        sharePasswordRequired:
+          type: boolean
     OAuthItem:
       description: |
         Information about a configured OAuth provider.

--- a/modules/restapi/src/main/resources/sharry-openapi.yml
+++ b/modules/restapi/src/main/resources/sharry-openapi.yml
@@ -2121,6 +2121,11 @@ components:
             auto-detect > this server default > UTC.
             If absent or empty, UTC is used (preserving previous behavior).
         sharePasswordRequired:
+          description: |
+            When true, authenticated users must set a password when
+            creating a share. The server enforces this on every upload
+            path; the UI shows the password field as required and blocks
+            submission without one.
           type: boolean
     OAuthItem:
       description: |

--- a/modules/restserver/src/main/resources/reference.conf
+++ b/modules/restserver/src/main/resources/reference.conf
@@ -427,6 +427,9 @@ sharry.restserver {
       # max-size at startup (a warning is logged in that case).
       zip-max-size = "1.5G"
 
+      # When true, authenticated users must provide a password when creating a share.
+      require-share-password = false
+
       # Allows additional database checks to be translated into some
       # meaningful message to the user.
       #

--- a/modules/restserver/src/main/scala/sharry/restserver/config/ConfigValues.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/config/ConfigValues.scala
@@ -360,8 +360,10 @@ object ConfigValues extends ConfigDecoders:
     )
       .listflatMap(domainCheck)
     val zipMaxSize = k("zip-max-size", "ZIP_MAX_SIZE").as[ByteSize]
-    val requireSharePassword = k("require-share-password", "REQUIRE_SHARE_PASSWORD").as[Boolean]
-    (chunkSize, maxSize, maxValid, domainChecks, zipMaxSize, requireSharePassword).mapN(ShareConfig.apply)
+    val requireSharePassword =
+      k("require-share-password", "REQUIRE_SHARE_PASSWORD").as[Boolean]
+    (chunkSize, maxSize, maxValid, domainChecks, zipMaxSize, requireSharePassword)
+      .mapN(ShareConfig.apply)
   }
 
   val cleanup = {

--- a/modules/restserver/src/main/scala/sharry/restserver/config/ConfigValues.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/config/ConfigValues.scala
@@ -360,7 +360,8 @@ object ConfigValues extends ConfigDecoders:
     )
       .listflatMap(domainCheck)
     val zipMaxSize = k("zip-max-size", "ZIP_MAX_SIZE").as[ByteSize]
-    (chunkSize, maxSize, maxValid, domainChecks, zipMaxSize).mapN(ShareConfig.apply)
+    val requireSharePassword = k("require-share-password", "REQUIRE_SHARE_PASSWORD").as[Boolean]
+    (chunkSize, maxSize, maxValid, domainChecks, zipMaxSize, requireSharePassword).mapN(ShareConfig.apply)
   }
 
   val cleanup = {

--- a/modules/restserver/src/main/scala/sharry/restserver/routes/InfoRoutes.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/routes/InfoRoutes.scala
@@ -81,7 +81,8 @@ object InfoRoutes {
       cfg.backend.auth.isProxyAuthOnly,
       cfg.backend.auth.isAutoLogin,
       cfg.backend.share.zipMaxSize,
-      cfg.webapp.defaultTimezone.filter(_.nonEmpty)
+      cfg.webapp.defaultTimezone.filter(_.nonEmpty),
+      cfg.backend.share.requireSharePassword
     )
   }
 

--- a/modules/restserver/src/main/scala/sharry/restserver/routes/ShareRoutes.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/routes/ShareRoutes.scala
@@ -201,14 +201,17 @@ object ShareRoutes {
         } yield resp).getOrElseF(NotFound())
 
       case DELETE -> Root / Ident(id) / "password" =>
-        (for {
-          res <-
-            backend.share
-              .setPassword(token.account, id, None)
-              .attempt
-              .map(AddResult.fromEither)
-          resp <- OptionT.liftF(Ok(Conv.basicResult(res, "Password deleted.")))
-        } yield resp).getOrElseF(NotFound())
+        if (cfg.backend.share.requireSharePassword)
+          Ok(BasicResult(false, "Password cannot be removed when password protection is required."))
+        else
+          (for {
+            res <-
+              backend.share
+                .setPassword(token.account, id, None)
+                .attempt
+                .map(AddResult.fromEither)
+            resp <- OptionT.liftF(Ok(Conv.basicResult(res, "Password deleted.")))
+          } yield resp).getOrElseF(NotFound())
     }
   }
 

--- a/modules/restserver/src/main/scala/sharry/restserver/routes/ShareRoutes.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/routes/ShareRoutes.scala
@@ -202,7 +202,12 @@ object ShareRoutes {
 
       case DELETE -> Root / Ident(id) / "password" =>
         if (cfg.backend.share.requireSharePassword)
-          Ok(BasicResult(false, "Password cannot be removed when password protection is required."))
+          Ok(
+            BasicResult(
+              false,
+              "Password cannot be removed when password protection is required."
+            )
+          )
         else
           (for {
             res <-

--- a/modules/webapp/src/main/elm/Messages/DetailPage.elm
+++ b/modules/webapp/src/main/elm/Messages/DetailPage.elm
@@ -697,6 +697,7 @@ br =
     , validityField = Messages.ValidityField.br
     , passwordRequired = "Senha obrigatória"
     , passwordInvalid = "Senha inválida"
+    , passwordCannotBeRemoved = "A senha não pode ser removida quando a proteção por senha é obrigatória."
     , or = "Ou"
     , dateTime = Messages.DateFormat.formatDateTime Language.Portuguese Time.utc
     , initialViewLabel =

--- a/modules/webapp/src/main/elm/Messages/DetailPage.elm
+++ b/modules/webapp/src/main/elm/Messages/DetailPage.elm
@@ -73,6 +73,7 @@ type alias Texts =
     , validityField : Messages.ValidityField.Texts
     , passwordRequired : String
     , passwordInvalid : String
+    , passwordCannotBeRemoved : String
     , or : String
     , dateTime : Int -> String
     , initialViewLabel : InitialView -> String
@@ -140,6 +141,7 @@ it =
     , validityField = Messages.ValidityField.it
     , passwordRequired = "Password necessaria"
     , passwordInvalid = "Password non valida"
+    , passwordCannotBeRemoved = "La password non può essere rimossa quando la protezione è obbligatoria."
     , or = "Oppure"
     , dateTime = Messages.DateFormat.formatDateTime Language.Italian Time.utc
     , initialViewLabel =
@@ -217,6 +219,7 @@ es =
     , validityField = Messages.ValidityField.es
     , passwordRequired = "Contraseña requerida"
     , passwordInvalid = "Contraseña inválida"
+    , passwordCannotBeRemoved = "No se puede eliminar la contraseña cuando la protección es obligatoria."
     , or = "O"
     , dateTime = Messages.DateFormat.formatDateTime Language.Spanish Time.utc
     , initialViewLabel =
@@ -295,6 +298,7 @@ gb =
     , validityField = Messages.ValidityField.gb
     , passwordRequired = "Password required"
     , passwordInvalid = "Password invalid"
+    , passwordCannotBeRemoved = "Password cannot be removed when password protection is required."
     , or = "Or"
     , dateTime = Messages.DateFormat.formatDateTime Language.English Time.utc
     , initialViewLabel =
@@ -374,6 +378,7 @@ de =
     , validityField = Messages.ValidityField.de
     , passwordRequired = "Passwort erforderlich"
     , passwordInvalid = "Passwort ungültig"
+    , passwordCannotBeRemoved = "Das Passwort kann nicht entfernt werden, wenn Passwortschutz erforderlich ist."
     , or = "Oder"
     , dateTime = Messages.DateFormat.formatDateTime Language.German Time.utc
     , initialViewLabel =
@@ -456,6 +461,7 @@ fr =
     , validityField = Messages.ValidityField.fr
     , passwordRequired = "Mot de passe requis"
     , passwordInvalid = "Mot de passe invalide"
+    , passwordCannotBeRemoved = "Le mot de passe ne peut pas être supprimé lorsque la protection est obligatoire."
     , or = "Ou"
     , dateTime = Messages.DateFormat.formatDateTime Language.French Time.utc
     , initialViewLabel =
@@ -532,6 +538,7 @@ ja =
     , validityField = Messages.ValidityField.ja
     , passwordRequired = "要パスワード"
     , passwordInvalid = "パスワードが無効"
+    , passwordCannotBeRemoved = "パスワード保護が必須の場合、パスワードを削除できません。"
     , or = "または"
     , dateTime = Messages.DateFormat.formatDateTime Language.Japanese Time.utc
     , initialViewLabel =
@@ -610,6 +617,7 @@ cz =
     , validityField = Messages.ValidityField.cz
     , passwordRequired = "Heslo vyžadováno"
     , passwordInvalid = "Chybějící heslo"
+    , passwordCannotBeRemoved = "Heslo nelze odebrat, pokud je vyžadována ochrana heslem."
     , or = "Nebo"
     , dateTime = Messages.DateFormat.formatDateTime Language.Czech Time.utc
     , initialViewLabel =

--- a/modules/webapp/src/main/elm/Messages/SharePage.elm
+++ b/modules/webapp/src/main/elm/Messages/SharePage.elm
@@ -313,4 +313,5 @@ br =
     , uploadsUpTo =
         \size ->
             "Os envios são possíveis até " ++ size ++ "."
+    , passwordRequiredToCreate = "É necessária uma senha para este compartilhamento."
     }

--- a/modules/webapp/src/main/elm/Messages/SharePage.elm
+++ b/modules/webapp/src/main/elm/Messages/SharePage.elm
@@ -42,6 +42,7 @@ type alias Texts =
     , gotoShare : String
     , maxPublicViews : String
     , uploadsUpTo : String -> String
+    , passwordRequiredToCreate : String
     }
 
 it : Texts
@@ -74,6 +75,7 @@ it =
     , uploadsUpTo =
         \size ->
             "Si possono caricare files fino a " ++ size ++ "."
+    , passwordRequiredToCreate = "È necessaria una password per questa condivisione."
     }
 
 
@@ -107,6 +109,7 @@ es =
     , uploadsUpTo =
         \size ->
             "Las subidas son posibles hasta " ++ size ++ "."
+    , passwordRequiredToCreate = "Se requiere una contraseña para este compartido."
     }
 
 
@@ -140,6 +143,7 @@ gb =
     , uploadsUpTo =
         \size ->
             "Uploads are possible up to " ++ size ++ "."
+    , passwordRequiredToCreate = "A password is required for this share."
     }
 
 
@@ -175,6 +179,7 @@ de =
     , uploadsUpTo =
         \size ->
             "Es kann bis zu " ++ size ++ " hochgeladen werden."
+    , passwordRequiredToCreate = "Für diese Datei-Freigabe ist ein Passwort erforderlich."
     }
 
 fr : Texts
@@ -207,6 +212,7 @@ fr =
     , uploadsUpTo =
         \size ->
             "Téléversements possibles jusqu'à " ++ size ++ "."
+    , passwordRequiredToCreate = "Un mot de passe est requis pour ce partage."
     }
 
 
@@ -240,6 +246,7 @@ ja =
     , uploadsUpTo =
         \size ->
             "アップロードは最大 " ++ size ++ " までです。"
+    , passwordRequiredToCreate = "この共有にはパスワードが必要です。"
     }
 
 cz : Texts
@@ -272,4 +279,5 @@ cz =
     , uploadsUpTo =
         \size ->
             "Velikost souborů je maximálně " ++ size ++ "."
+    , passwordRequiredToCreate = "Pro toto sdílení je vyžadováno heslo."
     }

--- a/modules/webapp/src/main/elm/Page/Detail/Data.elm
+++ b/modules/webapp/src/main/elm/Page/Detail/Data.elm
@@ -51,6 +51,7 @@ type alias Model =
     , uploadFormState : BasicResult
     , mailForm : Maybe Comp.MailSend.Model
     , shareUrlMode : InitialView
+    , passwordValidationError : Bool
     }
 
 
@@ -112,6 +113,7 @@ emptyModel =
     , uploadFormState = BasicResult True ""
     , mailForm = Nothing
     , shareUrlMode = Data.InitialView.default
+    , passwordValidationError = False
     }
 
 

--- a/modules/webapp/src/main/elm/Page/Detail/Update.elm
+++ b/modules/webapp/src/main/elm/Page/Detail/Update.elm
@@ -284,7 +284,7 @@ update flags msg model =
                         ( nm, nv ) =
                             Comp.PasswordInput.update lmsg m
                     in
-                    ( { model | editField = Just ( p, EditPassword ( nm, nv ) ) }
+                    ( { model | editField = Just ( p, EditPassword ( nm, nv ) ), passwordValidationError = False }
                     , Cmd.none
                     )
 
@@ -292,7 +292,7 @@ update flags msg model =
                     ( model, Cmd.none )
 
         CancelEdit ->
-            ( { model | editField = Nothing }, Cmd.none )
+            ( { model | editField = Nothing, passwordValidationError = False }, Cmd.none )
 
         EditKey code ->
             case code of
@@ -326,7 +326,13 @@ update flags msg model =
                     )
 
                 Just ( _, EditPassword ( _, pw ) ) ->
-                    ( nm, Api.setPassword flags model.share.id pw BasicResp )
+                    if flags.config.sharePasswordRequired && pw == Nothing then
+                        ( { model | passwordValidationError = True }
+                        , Cmd.none
+                        )
+
+                    else
+                        ( { nm | passwordValidationError = False }, Api.setPassword flags model.share.id pw BasicResp )
 
                 Nothing ->
                     ( nm, Cmd.none )

--- a/modules/webapp/src/main/elm/Page/Detail/View.elm
+++ b/modules/webapp/src/main/elm/Page/Detail/View.elm
@@ -1,6 +1,7 @@
 module Page.Detail.View exposing (view)
 
 import Api
+import Api.Model.BasicResult exposing (BasicResult)
 import Api.Model.ShareDetail exposing (ShareDetail)
 import Comp.Basic as B
 import Comp.ConfirmModal
@@ -60,7 +61,7 @@ view texts flags model =
             ++ shareProps texts flags model
             ++ shareLink texts flags model
             ++ [ dropzone texts flags model
-               , messageDiv model
+               , messageDiv texts model
                , descriptionView texts model desc
                , middleMenu texts model
                , fileList texts flags model
@@ -276,9 +277,13 @@ showUrlSwitch texts model =
         }
 
 
-messageDiv : Model -> Html Msg
-messageDiv model =
-    Util.Html.resultMsgMaybe model.message
+messageDiv : Texts -> Model -> Html Msg
+messageDiv texts model =
+    if model.passwordValidationError then
+        Util.Html.resultMsgMaybe (Just (BasicResult False texts.passwordCannotBeRemoved))
+
+    else
+        Util.Html.resultMsgMaybe model.message
 
 
 shareProps : Texts -> Flags -> Model -> List (Html Msg)

--- a/modules/webapp/src/main/elm/Page/Share/Data.elm
+++ b/modules/webapp/src/main/elm/Page/Share/Data.elm
@@ -32,6 +32,7 @@ type alias Model =
     , uploading : Bool
     , shareId : Maybe String
     , uploadPaused : Bool
+    , passwordValidationError : Bool
     }
 
 
@@ -52,6 +53,7 @@ emptyModel flags =
     , uploading = False
     , shareId = Nothing
     , uploadPaused = False
+    , passwordValidationError = False
     }
 
 

--- a/modules/webapp/src/main/elm/Page/Share/Update.elm
+++ b/modules/webapp/src/main/elm/Page/Share/Update.elm
@@ -51,7 +51,7 @@ update flags msg model =
                 ( m, pw ) =
                     Comp.PasswordInput.update lmsg model.passwordModel
             in
-            ( { model | passwordModel = m, passwordField = pw }
+            ( { model | passwordModel = m, passwordField = pw, passwordValidationError = False }
             , Cmd.none
             )
 
@@ -90,16 +90,28 @@ update flags msg model =
 
         Submit ->
             let
+                passwordOk =
+                    not flags.config.sharePasswordRequired || model.passwordField /= Nothing
+
                 valid =
-                    Util.Share.validate flags Nothing model
+                    if not passwordOk then
+                        BasicResult False ""
+
+                    else
+                        Util.Share.validate flags Nothing model
             in
-            if valid.success then
-                ( { model | uploading = True }
+            if passwordOk && valid.success then
+                ( { model | uploading = True, passwordValidationError = False }
                 , Api.createEmptyShare flags (makeProps model) CreateShareResp
                 )
 
+            else if not passwordOk then
+                ( { model | passwordValidationError = True }
+                , Cmd.none
+                )
+
             else
-                ( { model | formState = valid }
+                ( { model | formState = valid, passwordValidationError = False }
                 , Cmd.none
                 )
 

--- a/modules/webapp/src/main/elm/Page/Share/View.elm
+++ b/modules/webapp/src/main/elm/Page/Share/View.elm
@@ -51,10 +51,14 @@ view texts flags model =
         , div
             [ class S.errorMessage
             , classList
-                [ ( "hidden", model.formState.success && Tuple.second counts <= 0 )
+                [ ( "hidden", model.formState.success && Tuple.second counts <= 0 && not model.passwordValidationError )
                 ]
             ]
-            [ text model.formState.message
+            [ if model.passwordValidationError then
+                text texts.passwordRequiredToCreate
+
+              else
+                text model.formState.message
             ]
         , div [ class "flex flex-col" ]
             [ div [ class "mb-4" ]
@@ -112,6 +116,11 @@ view texts flags model =
             , div [ class "mb-4" ]
                 [ label [ class S.inputLabel ]
                     [ text texts.password
+                    , if flags.config.sharePasswordRequired then
+                        B.inputRequired
+
+                      else
+                        text ""
                     ]
                 , Html.map PasswordMsg
                     (Comp.PasswordInput.view


### PR DESCRIPTION
This PR implements #1777

When `sharry.restserver.backend.share.require-share-password = true`, authenticated users must set a password on every share they create.

- Share creation is blocked server side if no password is provided enforced on both upload paths, cannot be bypassed via API
- `DELETE /sec/share/:id/password` returns an error instead of removing the password
- UI marks the password field as required, shows a error message on submit without a password, and disables the remove-password action
- Alias uploads are unaffected

## Changes

- `ShareConfig`: new `requireSharePassword: Boolean` flag (default `false`)
- `UploadResult`: new `checkPasswordRequired` check, chained after `checkValidity`
- `OShare.create`: applies the check before inserting the share
- `ShareRoutes`: `DELETE /:id/password` guarded by the flag
- `InfoRoutes` / `AppConfig`: `sharePasswordRequired` exposed via `GET /api/v2/open/info/appconfig` so the frontend can adapt
- Elm frontend: `passwordValidationError` state added to Share and Detail pages; `passwordRequiredToCreate` and `passwordCannotBeRemoved` messages added in all 8 supported languages
- `reference.conf`, `configure.md`, `webapp.md`, `sharry-openapi.yml`: documentation