### PR TITLE
feat: add Brazilian Portuguese language support

### DIFF
--- a/modules/webapp/src/main/elm/Language.elm
+++ b/modules/webapp/src/main/elm/Language.elm
@@ -12,6 +12,7 @@ type Language
     | Czech
     | Spanish
     | Italian
+    | Portuguese
 
 allLanguages : List Language
 allLanguages =
@@ -22,4 +23,5 @@ allLanguages =
     , Czech
     , Spanish
     , Italian
+    , Portuguese
     ]

--- a/modules/webapp/src/main/elm/Messages.elm
+++ b/modules/webapp/src/main/elm/Messages.elm
@@ -70,6 +70,9 @@ get lang =
         Italian ->
             it
 
+        Portuguese ->
+            br
+
 {-| Get a ISO-3166-1 code of the given lanugage.
 -}
 toIso2 : Language -> String
@@ -279,4 +282,24 @@ cz =
     , upload = Messages.UploadPage.cz
     , newInvite = Messages.NewInvitePage.cz
     , settings = Messages.SettingsPage.cz
+    }
+
+
+br : Messages
+br =
+    { lang = Portuguese
+    , iso2 = "br"
+    , label = "Português (Brasil)"
+    , flagIcon = "fi fi-br"
+    , app = Messages.App.br
+    , login = Messages.LoginPage.br
+    , register = Messages.RegisterPage.br
+    , account = Messages.AccountPage.br
+    , aliasPage = Messages.AliasPage.br
+    , detail = Messages.DetailPage.br
+    , share = Messages.SharePage.br
+    , home = Messages.HomePage.br
+    , upload = Messages.UploadPage.br
+    , newInvite = Messages.NewInvitePage.br
+    , settings = Messages.SettingsPage.br
     }

--- a/modules/webapp/src/main/elm/Messages/AccountForm.elm
+++ b/modules/webapp/src/main/elm/Messages/AccountForm.elm
@@ -7,6 +7,7 @@ module Messages.AccountForm exposing
     , cz
     , es
     , it
+    , br
     )
 
 import Messages.FixedDropdown
@@ -134,5 +135,20 @@ cz =
     , email = "E-Mail"
     , yesNo = Messages.YesNoDimmer.cz
     , dropdown = Messages.FixedDropdown.cz
+    }
+
+br : Texts
+br =
+    { id = "Id"
+    , login = "Login"
+    , state = "Estado"
+    , admin = "Administrador"
+    , password = "Senha"
+    , submit = "Enviar"
+    , back = "Voltar"
+    , delete = "Excluir"
+    , email = "E-Mail"
+    , yesNo = Messages.YesNoDimmer.br
+    , dropdown = Messages.FixedDropdown.br
     }
 

--- a/modules/webapp/src/main/elm/Messages/AccountPage.elm
+++ b/modules/webapp/src/main/elm/Messages/AccountPage.elm
@@ -7,6 +7,7 @@ module Messages.AccountPage exposing
     , cz
     , es
     , it
+    , br
     )
 
 import Messages.AccountForm
@@ -93,6 +94,16 @@ cz =
     , newAccount = "Nový účet"
     , accountForm = Messages.AccountForm.cz
     , accountTable = Messages.AccountTable.cz
+    }
+
+br : Texts
+br =
+    { createAccountTitle = "Criar uma nova conta interna"
+    , accounts = "Contas"
+    , searchPlaceholder = "Buscar…"
+    , newAccount = "Nova Conta"
+    , accountForm = Messages.AccountForm.br
+    , accountTable = Messages.AccountTable.br
     }
 
 

--- a/modules/webapp/src/main/elm/Messages/AccountTable.elm
+++ b/modules/webapp/src/main/elm/Messages/AccountTable.elm
@@ -8,6 +8,7 @@ module Messages.AccountTable exposing
     , cz
     , es
     , it
+    , br
     )
 
 import Language exposing (Language)
@@ -132,6 +133,20 @@ cz  =
     , created = "Založeno"
     , edit = "Editovat"
     , dateTime = formatDateTime Language.Czech Time.utc
+    }
+
+br : Texts
+br =
+    { login = "Login"
+    , source = "Origem"
+    , state = "Estado"
+    , nrShares = "#Compartilhamentos"
+    , admin = "Administrador"
+    , nrLogins = "#Logins"
+    , lastLogin = "Último Login"
+    , created = "Criado"
+    , edit = "Editar"
+    , dateTime = formatDateTime Language.Portuguese Time.utc
     }
 
 

--- a/modules/webapp/src/main/elm/Messages/AliasForm.elm
+++ b/modules/webapp/src/main/elm/Messages/AliasForm.elm
@@ -7,6 +7,7 @@ module Messages.AliasForm exposing
     , cz
     , es
     , it
+    , br
     )
 
 import Html exposing (..)
@@ -211,4 +212,30 @@ cz =
     , memberInfo = "Členové tohoto prostoru jej mohou zobrazit a sdílet. Dále uvidí všechny soubory, které byly do tohoto prostoru nahrány."
     , yesNo = Messages.YesNoDimmer.cz
     , validityField = Messages.ValidityField.cz
+    }
+
+br : Texts
+br =
+    { id = "Id"
+    , noteToIdsHead = "Nota sobre Ids"
+    , noteToIds =
+        p []
+            [ text "Este ID faz parte da URL onde "
+            , em [] [ text "qualquer pessoa" ]
+            , text " pode enviar arquivos. Recomenda-se usar"
+            , text " algo aleatório. O id pode ser alterado para "
+            , text "qualquer valor, mas se deixado vazio, será gerado"
+            , text " um valor aleatório."
+            ]
+    , name = "Nome"
+    , validity = "Validade"
+    , enabled = "Habilitado"
+    , submit = "Enviar"
+    , back = "Voltar"
+    , delete = "Excluir"
+    , searchPlaceholder = "Buscar…"
+    , members = "Membros"
+    , memberInfo = "Os membros do seu alias podem ver e compartilhar este alias e podem ver todos os envios recebidos por este alias."
+    , yesNo = Messages.YesNoDimmer.br
+    , validityField = Messages.ValidityField.br
     }

--- a/modules/webapp/src/main/elm/Messages/AliasPage.elm
+++ b/modules/webapp/src/main/elm/Messages/AliasPage.elm
@@ -7,6 +7,7 @@ module Messages.AliasPage exposing
     , cz
     , es
     , it
+    , br
     )
 
 import Messages.AliasForm
@@ -175,5 +176,25 @@ cz =
     , aliasForm = Messages.AliasForm.cz
     , aliasTable = Messages.AliasTable.cz
     , mailSend = Messages.MailSend.cz
+    }
+
+br : Texts
+br =
+    { createNew = "Criar Nova Página de Alias"
+    , aliasPage = "Página de Alias: "
+    , aliasPages = "Páginas de Alias"
+    , newAliasPage = "Nova Página de Alias"
+    , searchPlaceholder = "Buscar…"
+    , errorQrCode = "Erro ao gerar o QR Code."
+    , shareThisLink = "Compartilhar este link"
+    , aliasPageNowAt = "A página de alias está em: "
+    , shareThisUrl = "Você pode compartilhar esta URL com outros para receber arquivos deles."
+    , sendEmail = "Enviar E-Mail"
+    , copyLink = "Copiar Link"
+    , owner = "Proprietário"
+    , notOwnerInfo = "Este alias pertence a outro usuário e foi compartilhado com você. Você não pode editar suas propriedades."
+    , aliasForm = Messages.AliasForm.br
+    , aliasTable = Messages.AliasTable.br
+    , mailSend = Messages.MailSend.br
     }
 

--- a/modules/webapp/src/main/elm/Messages/AliasTable.elm
+++ b/modules/webapp/src/main/elm/Messages/AliasTable.elm
@@ -8,6 +8,7 @@ module Messages.AliasTable exposing
     , cz
     , es
     , it
+    , br
     )
 
 import Language exposing (Language)
@@ -121,6 +122,19 @@ cz =
     , owner = "Vlastník"
     , validityField = Messages.ValidityField.cz
     , dateTime = Messages.DateFormat.formatDateTime Language.Czech Time.utc
+    }
+
+br : Texts
+br =
+    { name = "Nome"
+    , enabled = "Habilitado"
+    , validity = "Validade"
+    , created = "Criado"
+    , edit = "Editar"
+    , show = "Mostrar"
+    , owner = "Proprietário"
+    , validityField = Messages.ValidityField.br
+    , dateTime = Messages.DateFormat.formatDateTime Language.Portuguese Time.utc
     }
 
 

--- a/modules/webapp/src/main/elm/Messages/App.elm
+++ b/modules/webapp/src/main/elm/Messages/App.elm
@@ -7,6 +7,7 @@ module Messages.App exposing
     , cz
     , es
     , it
+    , br
     )
 
 
@@ -139,4 +140,20 @@ cz =
     , lightDark = "Světlý/Tmavý režim"
     , logoutSharry = "Odhlásit"
     , logoutOAuth = "Odhlásit u poskytovatele ověření"
+    }
+
+br : Texts
+br =
+    { home = "Início"
+    , shares = "Compartilhamentos"
+    , aliases = "Aliases"
+    , accounts = "Contas"
+    , settings = "Configurações"
+    , newInvites = "Novos Convites"
+    , logout = \user -> "Sair (" ++ user ++ ")"
+    , login = "Entrar"
+    , register = "Registrar"
+    , lightDark = "Claro/Escuro"
+    , logoutSharry = "Sair do Sharry"
+    , logoutOAuth = "Sair do provedor de autenticação"
     }

--- a/modules/webapp/src/main/elm/Messages/DateFormat.elm
+++ b/modules/webapp/src/main/elm/Messages/DateFormat.elm
@@ -40,6 +40,9 @@ get lang =
         Italian ->
             it
 
+        Portuguese ->
+            br
+
 formatDateTime : Language -> Time.Zone -> Int -> String
 formatDateTime lang zone millis =
     let
@@ -184,6 +187,25 @@ cz =
         , DateFormat.minuteFixed
         ]
     , lang = czech
+    }
+
+
+br : DateTimeMsg
+br =
+    { format =
+        [ DateFormat.dayOfWeekNameAbbreviated
+        , DateFormat.text ", "
+        , DateFormat.dayOfMonthSuffix
+        , DateFormat.text " de "
+        , DateFormat.monthNameFull
+        , DateFormat.text " de "
+        , DateFormat.yearNumber
+        , DateFormat.text ", "
+        , DateFormat.hourMilitaryNumber
+        , DateFormat.text ":"
+        , DateFormat.minuteFixed
+        ]
+    , lang = portuguese
     }
 
 
@@ -628,6 +650,130 @@ toCzechWeekdayName weekday =
 
         Sun ->
             "Neděle"
+
+-- Portuguese (Brazil)
+
+
+{-| Brazilian Portuguese language!
+-}
+portuguese : DL.Language
+portuguese =
+    let
+        withDot str =
+            str ++ "."
+    in
+    DL.Language
+        toPortugueseMonthName
+        toPortugueseMonthAbbreviation
+        toPortugueseWeekdayName
+        (toPortugueseWeekdayName >> String.left 3 >> withDot)
+        toEnglishAmPm
+        (\_ -> "")
+
+
+toPortugueseMonthName : Month -> String
+toPortugueseMonthName month =
+    case month of
+        Jan ->
+            "janeiro"
+
+        Feb ->
+            "fevereiro"
+
+        Mar ->
+            "março"
+
+        Apr ->
+            "abril"
+
+        May ->
+            "maio"
+
+        Jun ->
+            "junho"
+
+        Jul ->
+            "julho"
+
+        Aug ->
+            "agosto"
+
+        Sep ->
+            "setembro"
+
+        Oct ->
+            "outubro"
+
+        Nov ->
+            "novembro"
+
+        Dec ->
+            "dezembro"
+
+
+toPortugueseMonthAbbreviation : Month -> String
+toPortugueseMonthAbbreviation month =
+    case month of
+        Jan ->
+            "jan"
+
+        Feb ->
+            "fev"
+
+        Mar ->
+            "mar"
+
+        Apr ->
+            "abr"
+
+        May ->
+            "mai"
+
+        Jun ->
+            "jun"
+
+        Jul ->
+            "jul"
+
+        Aug ->
+            "ago"
+
+        Sep ->
+            "set"
+
+        Oct ->
+            "out"
+
+        Nov ->
+            "nov"
+
+        Dec ->
+            "dez"
+
+
+toPortugueseWeekdayName : Weekday -> String
+toPortugueseWeekdayName weekday =
+    case weekday of
+        Mon ->
+            "segunda-feira"
+
+        Tue ->
+            "terça-feira"
+
+        Wed ->
+            "quarta-feira"
+
+        Thu ->
+            "quinta-feira"
+
+        Fri ->
+            "sexta-feira"
+
+        Sat ->
+            "sábado"
+
+        Sun ->
+            "domingo"
 
 
 

--- a/modules/webapp/src/main/elm/Messages/DetailPage.elm
+++ b/modules/webapp/src/main/elm/Messages/DetailPage.elm
@@ -8,6 +8,7 @@ module Messages.DetailPage exposing
     , cz
     , es
     , it
+    , br
     )
 
 import Data.InitialView exposing (InitialView)
@@ -624,6 +625,84 @@ cz =
                 Data.InitialView.Zoom ->
                     "Náhled"
     , initialViewField = "Výchozí zobrazení: "
+    }
+
+
+br : Texts
+br =
+    { mailSend = Messages.MailSend.br
+    , save = "Salvar"
+    , cancel = "Cancelar"
+    , yourShare = "Seu Compartilhamento"
+    , markdownInput = Messages.MarkdownInput.br
+    , shareFileList = Messages.ShareFileList.br
+    , yesNo = Messages.YesNoDimmer.br
+    , sharePublished =
+        "O compartilhamento foi publicado, mas o limite de visualizações foi atingido. Você pode "
+            ++ "aumentar esta propriedade se desejar mantê-lo publicado por mais tempo."
+    , shareNotPublished =
+        "Para compartilhar isso com outros, você precisa publicar "
+            ++ "este compartilhamento. Então todos a quem você enviar o link gerado "
+            ++ "poderão acessar estes dados."
+    , shareLinkExpired =
+        "O compartilhamento foi publicado, mas agora está expirado. Você pode "
+            ++ "despublicar e depois publicá-lo novamente."
+    , errorQrCode = "Erro ao gerar o QR Code."
+    , sharePublicAvailableAt = "O compartilhamento está disponível publicamente em"
+    , shareAsYouLike = "Você pode compartilhar este link com todos que desejar que acessem estes dados."
+    , sendEmail = "Enviar E-Mail"
+    , copyLink = "Copiar Link"
+    , name = "Nome"
+    , validity = "Tempo de Validade"
+    , maxViews = "Máx. Visualizações"
+    , password = "Senha"
+    , passwordProtected = "Protegido por Senha"
+    , passwordNone = "Nenhuma"
+    , shareSize = "#/Tamanho"
+    , created = "Criado"
+    , aliasLabel = "Alias"
+    , publishedOn = "Publicado em"
+    , publishedUntil = "Publicado até"
+    , lastAccess = "Último Acesso"
+    , views = "Visualizações"
+    , publishWithNewLink = "Publicar com novo Link"
+    , delete = "Excluir"
+    , edit = "Editar"
+    , detailsMenu = "Detalhes"
+    , shareLinkMenu = "Link Compartilhado"
+    , addFilesLinkMenu = "Adicionar arquivos"
+    , editDescription = "Editar descrição"
+    , publish = "Publicar"
+    , unpublish = "Despublicar"
+    , listView = "Visualização em Lista"
+    , cardView = "Visualização em Cartões"
+    , submit = "Enviar"
+    , clear = "Limpar"
+    , resume = "Retomar"
+    , pause = "Pausar"
+    , uploadsGreaterThan =
+        \size ->
+            "Todos os envios não devem ser maiores que " ++ size ++ "."
+    , waitDeleteShare = "Excluindo compartilhamento. Aguarde."
+    , loadingData = "Carregando dados..."
+    , dropzone = Messages.Dropzone2.br
+    , validityField = Messages.ValidityField.br
+    , passwordRequired = "Senha obrigatória"
+    , passwordInvalid = "Senha inválida"
+    , or = "Ou"
+    , dateTime = Messages.DateFormat.formatDateTime Language.Portuguese Time.utc
+    , initialViewLabel =
+        \iv ->
+            case iv of
+                Data.InitialView.Listing ->
+                    "Lista"
+
+                Data.InitialView.Cards ->
+                    "Cartões"
+
+                Data.InitialView.Zoom ->
+                    "Visualização"
+    , initialViewField = "Visualização inicial"
     }
 
 

--- a/modules/webapp/src/main/elm/Messages/Dropzone2.elm
+++ b/modules/webapp/src/main/elm/Messages/Dropzone2.elm
@@ -7,6 +7,7 @@ module Messages.Dropzone2 exposing
     , cz
     , es
     , it
+    , br
     )
 
 
@@ -73,4 +74,12 @@ cz =
     , filesSelected = " vybrané soubory ("
     , or = "nebo"
     , selectFiles = "vyberte soubory ..."
+    }
+
+br : Texts
+br =
+    { dropHere = "Solte os arquivos aqui"
+    , filesSelected = " arquivos selecionados ("
+    , or = "Ou"
+    , selectFiles = "Selecionar Arquivos ..."
     }

--- a/modules/webapp/src/main/elm/Messages/FixedDropdown.elm
+++ b/modules/webapp/src/main/elm/Messages/FixedDropdown.elm
@@ -7,6 +7,7 @@ module Messages.FixedDropdown exposing
     , cz
     , es
     , it
+    , br
     )
 
 
@@ -49,5 +50,10 @@ ja =
 cz : Texts
 cz =
     { select = "Vybrat…"
+    }
+
+br : Texts
+br =
+    { select = "Selecionar…"
     }
 

--- a/modules/webapp/src/main/elm/Messages/HomePage.elm
+++ b/modules/webapp/src/main/elm/Messages/HomePage.elm
@@ -7,6 +7,7 @@ module Messages.HomePage exposing
     , cz
     , es
     , it
+    , br
     )
 
 
@@ -90,4 +91,14 @@ cz =
     , viewAliases = "Zobrazit prostory pro sdílení"
     , documentation = "Dokumentace"
     , shareFilesWithOthers = "Sdílení souborů"
+    }
+
+br : Texts
+br =
+    { createShare = "Criar Compartilhamento"
+    , viewShares = "Ver Compartilhamentos"
+    , createAlias = "Criar Alias"
+    , viewAliases = "Ver Aliases"
+    , documentation = "Documentação"
+    , shareFilesWithOthers = "Compartilhar arquivos com outros"
     }

--- a/modules/webapp/src/main/elm/Messages/IntField.elm
+++ b/modules/webapp/src/main/elm/Messages/IntField.elm
@@ -7,6 +7,7 @@ module Messages.IntField exposing
     , cz
     , es
     , it
+    , br
     )
 
 
@@ -67,4 +68,11 @@ cz =
     { mustBeLower = "Číslo musí být <= "
     , mustBeGreater = "Číslo musí být >= "
     , notANumber = \str -> "'" ++ str ++ "' není povolená hodnota!"
+    }
+
+br : Texts
+br =
+    { mustBeLower = "O número deve ser <= "
+    , mustBeGreater = "O número deve ser >= "
+    , notANumber = \str -> "'" ++ str ++ "' não é um número válido!"
     }

--- a/modules/webapp/src/main/elm/Messages/LoginPage.elm
+++ b/modules/webapp/src/main/elm/Messages/LoginPage.elm
@@ -7,6 +7,7 @@ module Messages.LoginPage exposing
     , cz
     , es
     , it
+    , br
     )
 
 import Messages.FixedDropdown
@@ -131,5 +132,20 @@ cz =
     , signupLink = "Zaregistrovat se"
     , or = "Nebo"
     , dropdown = Messages.FixedDropdown.cz
+    }
+
+br : Texts
+br =
+    { username = "Nome de usuário"
+    , password = "Senha"
+    , loginPlaceholder = "Usuário"
+    , passwordPlaceholder = "Senha"
+    , loginButton = "Entrar"
+    , via = "via"
+    , loginSuccessful = "Login realizado com sucesso"
+    , noAccount = "Não tem uma conta?"
+    , signupLink = "Cadastre-se!"
+    , or = "Ou"
+    , dropdown = Messages.FixedDropdown.br
     }
 

--- a/modules/webapp/src/main/elm/Messages/MailForm.elm
+++ b/modules/webapp/src/main/elm/Messages/MailForm.elm
@@ -7,6 +7,7 @@ module Messages.MailForm exposing
     , cz
     , es
     , it
+    , br
     )
 
 
@@ -90,5 +91,15 @@ cz =
     , body = "Tělo"
     , send = "Odeslat"
     , cancel = "Storno"
+    }
+
+br : Texts
+br =
+    { receivers = "Destinatário(s)"
+    , separateRecipientsByComma = "Separe múltiplos destinatários com vírgula"
+    , subject = "Assunto"
+    , body = "Corpo"
+    , send = "Enviar"
+    , cancel = "Cancelar"
     }
 

--- a/modules/webapp/src/main/elm/Messages/MailSend.elm
+++ b/modules/webapp/src/main/elm/Messages/MailSend.elm
@@ -7,6 +7,7 @@ module Messages.MailSend exposing
     , cz
     , es
     , it
+    , br
     )
 
 import Messages.MailForm
@@ -68,4 +69,11 @@ cz =
     { sendingEmail = "Odeslat mail ..."
     , loadingTemplate = "Nahrát šablonu ..."
     , mailForm = Messages.MailForm.cz
+    }
+
+br : Texts
+br =
+    { sendingEmail = "Enviando e-mail ..."
+    , loadingTemplate = "Carregando modelo ..."
+    , mailForm = Messages.MailForm.br
     }

--- a/modules/webapp/src/main/elm/Messages/MarkdownInput.elm
+++ b/modules/webapp/src/main/elm/Messages/MarkdownInput.elm
@@ -7,6 +7,7 @@ module Messages.MarkdownInput exposing
     , cz
     , es
     , it
+    , br
     )
 
 
@@ -73,4 +74,12 @@ cz =
     , preview = "Náhled"
     , split = "Rozdělit"
     , supportsMarkdown = "Podporuje Markdown"
+    }
+
+br : Texts
+br =
+    { edit = "Editar"
+    , preview = "Visualizar"
+    , split = "Dividir"
+    , supportsMarkdown = "Suporta Markdown"
     }

--- a/modules/webapp/src/main/elm/Messages/NewInvitePage.elm
+++ b/modules/webapp/src/main/elm/Messages/NewInvitePage.elm
@@ -7,6 +7,7 @@ module Messages.NewInvitePage exposing
     , cz
     , es
     , it
+    , br
     )
 
 import Html exposing (Html, p, text)
@@ -225,6 +226,35 @@ cz =
             [ text
                 """Vytvoření pozvánky vyžaduje zadání hesla
              z konfigurace."""
+            ]
+        ]
+    }
+
+br : Texts
+br =
+    { createNewTitle = "Criar novos convites"
+    , newInvitePassword = "Senha do Convite"
+    , submit = "Enviar"
+    , reset = "Redefinir"
+    , error = "Erro"
+    , success = "Sucesso"
+    , invitationKey = "Chave de Convite:"
+    , message =
+        [ p []
+            [ text
+                """O Sharry exige um convite para se cadastrar.
+                Você pode criar esses convites aqui e enviá-los para quem desejar
+                para que possam se cadastrar no Sharry."""
+            ]
+        , p []
+            [ text
+                """Cada convite só pode ser usado uma vez.
+                Você precisará criar uma chave para cada pessoa que deseja convidar."""
+            ]
+        , p []
+            [ text
+                """Criar um convite exige informar a senha
+                definida na configuração."""
             ]
         ]
     }

--- a/modules/webapp/src/main/elm/Messages/RegisterPage.elm
+++ b/modules/webapp/src/main/elm/Messages/RegisterPage.elm
@@ -7,6 +7,7 @@ module Messages.RegisterPage exposing
     , cz
     , es
     , it
+    , br
     )
 
 import Messages.FixedDropdown
@@ -125,5 +126,19 @@ cz =
     , signin = "Přihlásit se"
     , registrationSuccessful = "Registrace byla úspěšná."
     , dropdown = Messages.FixedDropdown.cz
+    }
+
+br : Texts
+br =
+    { signup = "Cadastro"
+    , userLogin = "Nome de usuário"
+    , password = "Senha"
+    , passwordRepeat = "Senha (repetir)"
+    , invitationKey = "Chave de Convite"
+    , submitButton = "Enviar"
+    , alreadySignedUp = "Já está cadastrado?"
+    , signin = "Entrar"
+    , registrationSuccessful = "Cadastro realizado com sucesso."
+    , dropdown = Messages.FixedDropdown.br
     }
 

--- a/modules/webapp/src/main/elm/Messages/SettingsPage.elm
+++ b/modules/webapp/src/main/elm/Messages/SettingsPage.elm
@@ -7,6 +7,7 @@ module Messages.SettingsPage exposing
     , cz
     , es
     , it
+    , br
     )
 
 
@@ -171,4 +172,24 @@ cz =
     , timezoneManualLabel = "Aktuální časové pásmo:"
     , timezoneResetButton = "Obnovit automatické"
     , timezoneInputPlaceholder = "Např. Europe/Prague"
+    }
+
+br : Texts
+br =
+    { settingsTitle = "Configurações"
+    , changeMailHeader = "Alterar seu E-Mail"
+    , newEmail = "Novo E-Mail"
+    , newEmailPlaceholder = "Endereço de E-Mail"
+    , submitEmptyMailInfo = "Enviar um formulário vazio exclui o endereço de e-mail."
+    , submit = "Enviar"
+    , changePasswordHeader = "Alterar Senha"
+    , currentPassword = "Senha Atual"
+    , newPassword = "Nova Senha"
+    , newPasswordRepeat = "Nova Senha (Repetir)"
+    , timezoneHeader = "Fuso Horário"
+    , timezoneAutoLabel = "Automático (do navegador)"
+    , timezoneAutoHint = "O fuso horário é detectado automaticamente pelo navegador."
+    , timezoneManualLabel = "Fuso horário atual:"
+    , timezoneResetButton = "Restaurar automático"
+    , timezoneInputPlaceholder = "Ex. America/Sao_Paulo"
     }

--- a/modules/webapp/src/main/elm/Messages/ShareFileList.elm
+++ b/modules/webapp/src/main/elm/Messages/ShareFileList.elm
@@ -7,6 +7,7 @@ module Messages.ShareFileList exposing
     , cz
     , es
     , it
+    , br
     )
 
 import Messages.YesNoDimmer
@@ -156,4 +157,22 @@ cz =
     , fileIsIncomplete = "Soubor nebyl nahrán celý ("
     , tryUploadAgain = "%). Nahrajte jej prosím znovu."
     , yesNo = Messages.YesNoDimmer.cz
+    }
+
+br : Texts
+br =
+    { previewNotSupported = "Visualização não suportada"
+    , downloadToDisk = "Baixar para o disco"
+    , downloadAllZip = "Baixar tudo como ZIP"
+    , downloadSelectedZip = "Baixar selecionados como ZIP"
+    , selectAll = "Selecionar tudo"
+    , deselectAll = "Desmarcar tudo"
+    , noFilesSelected = "Nenhum arquivo selecionado"
+    , selectionTooLarge = "Seleção muito grande para download ZIP"
+    , selectedSizeOf = " de "
+    , viewInBrowser = "Ver no navegador"
+    , deleteFile = "Excluir o arquivo."
+    , fileIsIncomplete = "O arquivo está incompleto ("
+    , tryUploadAgain = "%). Tente enviar novamente."
+    , yesNo = Messages.YesNoDimmer.br
     }

--- a/modules/webapp/src/main/elm/Messages/SharePage.elm
+++ b/modules/webapp/src/main/elm/Messages/SharePage.elm
@@ -7,6 +7,7 @@ module Messages.SharePage exposing
     , cz
     , es
     , it
+    , br
     )
 
 import Messages.Dropzone2
@@ -272,4 +273,36 @@ cz =
     , uploadsUpTo =
         \size ->
             "Velikost souborů je maximálně " ++ size ++ "."
+    }
+
+br : Texts
+br =
+    { markdownInput = Messages.MarkdownInput.br
+    , dropzone = Messages.Dropzone2.br
+    , validityField = Messages.ValidityField.br
+    , intField = Messages.IntField.br
+    , sendFiles = "Enviar arquivos"
+    , description = "Descrição"
+    , sendMoreFiles = "Enviar mais arquivos"
+    , allFilesUploaded = "Todos os arquivos enviados"
+    , someFilesFailedHeader = "Alguns arquivos falharam"
+    , someFilesFailedText = "Alguns arquivos falharam no envio…. Você pode tentar enviá-los novamente. "
+    , someFilesFailedTextAddon = "Vá ao compartilhamento e envie o mesmo arquivo novamente."
+    , submit = "Enviar"
+    , clearFiles = "Limpar Arquivos"
+    , resume = "Retomar"
+    , pause = "Pausar"
+    , password = "Senha"
+    , createShare = "Criar um Compartilhamento"
+    , details = "Detalhes"
+    , name = "Nome"
+    , namePlaceholder = "Nome Opcional"
+    , validity = "Validade"
+    , files = "Arquivos"
+    , newShare = "Novo Compartilhamento"
+    , gotoShare = "Ir ao Compartilhamento"
+    , maxPublicViews = "Máximo de Visualizações Públicas"
+    , uploadsUpTo =
+        \size ->
+            "Os envios são possíveis até " ++ size ++ "."
     }

--- a/modules/webapp/src/main/elm/Messages/ShareTable.elm
+++ b/modules/webapp/src/main/elm/Messages/ShareTable.elm
@@ -8,6 +8,7 @@ module Messages.ShareTable exposing
     , cz
     , es
     , it
+    , br
     )
 
 import Language exposing (Language)
@@ -121,6 +122,19 @@ cz =
     , created = "Vytvořeno"
     , open = "Otevřít"
     , dateTime = Messages.DateFormat.formatDateTime Language.Czech Time.utc
+    }
+
+br : Texts
+br =
+    { nameId = "Nome/Id"
+    , aliasLabel = "Alias"
+    , maxViews = "Máx. Visualizações"
+    , published = "Publicado"
+    , nFiles = "#Arquivos"
+    , size = "Tamanho"
+    , created = "Criado"
+    , open = "Abrir"
+    , dateTime = Messages.DateFormat.formatDateTime Language.Portuguese Time.utc
     }
 
 

--- a/modules/webapp/src/main/elm/Messages/UploadPage.elm
+++ b/modules/webapp/src/main/elm/Messages/UploadPage.elm
@@ -7,6 +7,7 @@ module Messages.UploadPage exposing
     , cz
     , es
     , it
+    , br
     )
 
 import Messages.ShareTable
@@ -77,4 +78,12 @@ cz =
     , newShare = "Nové sdílení"
     , search = "Hledat…"
     , shareTable = Messages.ShareTable.cz
+    }
+
+br : Texts
+br =
+    { yourShares = "Seus Compartilhamentos"
+    , newShare = "Novo Compartilhamento"
+    , search = "Buscar…"
+    , shareTable = Messages.ShareTable.br
     }

--- a/modules/webapp/src/main/elm/Messages/ValidityField.elm
+++ b/modules/webapp/src/main/elm/Messages/ValidityField.elm
@@ -7,6 +7,7 @@ module Messages.ValidityField exposing
     , cz
     , es
     , it
+    , br
     )
 
 import Messages.FixedDropdown
@@ -117,4 +118,17 @@ cz =
     , weeks = "týdnů"
     , month = "měsíc"
     , months = "měsíců"
+    }
+
+br : Texts
+br =
+    { dropdown = Messages.FixedDropdown.br
+    , hour = "hora"
+    , hours = "horas"
+    , day = "dia"
+    , days = "dias"
+    , week = "semana"
+    , weeks = "semanas"
+    , month = "mês"
+    , months = "meses"
     }

--- a/modules/webapp/src/main/elm/Messages/YesNoDimmer.elm
+++ b/modules/webapp/src/main/elm/Messages/YesNoDimmer.elm
@@ -7,6 +7,7 @@ module Messages.YesNoDimmer exposing
     , cz
     , es
     , it
+    , br
     )
 
 
@@ -65,4 +66,11 @@ cz =
     { message = "Smazat trvale tuto položku?"
     , confirmButton = "Ano, prosím!"
     , cancelButton = "Ne"
+    }
+
+br : Texts
+br =
+    { message = "Excluir este item permanentemente?"
+    , confirmButton = "Sim, excluir!"
+    , cancelButton = "Não"
     }


### PR DESCRIPTION
- Added Portuguese as a new language option in the Language module.
- Implemented translations for various modules including Messages, AccountForm, AccountPage, and others to support Brazilian Portuguese.
- Updated date formatting and other relevant components to accommodate the new language.