### PR TITLE
Upload percent error

### DIFF
--- a/modules/backend/src/main/scala/sharry/backend/share/OShare.scala
+++ b/modules/backend/src/main/scala/sharry/backend/share/OShare.scala
@@ -293,7 +293,10 @@ object OShare {
               .flatMap { bytesSaved =>
                 val len = offset + ByteSize(bytesSaved)
                 store
-                  .transact(RShareFile.setRealSize(fileId, len))
+                  .transact(
+                    RShareFile.setRealSize(fileId, len) >>
+                      RFileMeta.updateLength(fileMetaId, len)
+                  )
                   .map(_ => UploadResult.success(len))
               }
               .attempt

--- a/modules/store/src/main/resources/db/migration/h2/V1.2.2__fix_chunk_data_type.sql
+++ b/modules/store/src/main/resources/db/migration/h2/V1.2.2__fix_chunk_data_type.sql
@@ -1,10 +1,9 @@
--- Fix: change chunk_data from BLOB/MEDIUMBLOB back to VARBINARY.
--- H2's LENGTH() on BLOB columns (introduced by V1.0.1) returns UTF-8 character
--- count instead of byte count, causing filemeta.length to be underreported.
--- NOTE: Even with VARBINARY, LENGTH() still returns char count in H2 PostgreSQL
--- mode; the Scala-level updateLength() in OShare.scala bypasses this for new uploads.
-ALTER TABLE "filechunk" ALTER COLUMN "chunk_data" VARBINARY(1000000000) NOT NULL;
-
+-- Fix filemeta.length for existing files.
+-- H2 in PostgreSQL mode: LENGTH() on both MEDIUMBLOB and VARBINARY returns UTF-8
+-- character count, not byte count. OCTET_LENGTH() is reliable on MEDIUMBLOB, so
+-- no column type change is needed. New uploads are fixed in OShare.scala via
+-- Scala-computed updateLength() which never calls LENGTH() on chunk_data.
+--
 -- Recompute filemeta.length for existing files using correct byte count.
 -- Only updates rows that have chunks (files uploaded before this migration).
 UPDATE "filemeta"

--- a/modules/store/src/main/resources/db/migration/h2/V1.2.2__fix_chunk_data_type.sql
+++ b/modules/store/src/main/resources/db/migration/h2/V1.2.2__fix_chunk_data_type.sql
@@ -1,0 +1,18 @@
+-- Fix: change chunk_data from BLOB/MEDIUMBLOB back to VARBINARY.
+-- H2's LENGTH() on BLOB columns (introduced by V1.0.1) returns UTF-8 character
+-- count instead of byte count, causing filemeta.length to be underreported.
+-- NOTE: Even with VARBINARY, LENGTH() still returns char count in H2 PostgreSQL
+-- mode; the Scala-level updateLength() in OShare.scala bypasses this for new uploads.
+ALTER TABLE "filechunk" ALTER COLUMN "chunk_data" VARBINARY(1000000000) NOT NULL;
+
+-- Recompute filemeta.length for existing files using correct byte count.
+-- Only updates rows that have chunks (files uploaded before this migration).
+UPDATE "filemeta"
+SET "length" = (
+  SELECT SUM(OCTET_LENGTH(fc."chunk_data"))
+  FROM "filechunk" fc
+  WHERE fc."file_id" = "filemeta"."file_id"
+)
+WHERE EXISTS (
+  SELECT 1 FROM "filechunk" fc2 WHERE fc2."file_id" = "filemeta"."file_id"
+);

--- a/modules/store/src/main/scala/sharry/store/records/RFileMeta.scala
+++ b/modules/store/src/main/scala/sharry/store/records/RFileMeta.scala
@@ -73,6 +73,9 @@ object RFileMeta {
   def updateChecksum(id: Ident, checksum: ByteVector): ConnectionIO[Int] =
     Sql.updateRow(table, Columns.id.is(id), Columns.checksum.setTo(checksum)).update.run
 
+  def updateLength(id: Ident, length: ByteSize): ConnectionIO[Int] =
+    Sql.updateRow(table, Columns.id.is(id), Columns.length.setTo(length)).update.run
+
   def delete(id: Ident): ConnectionIO[Int] =
     Sql.deleteFrom(table, Columns.id.is(id)).update.run
 }

--- a/modules/store/src/test/scala/sharry/store/H2BlobLengthTest.scala
+++ b/modules/store/src/test/scala/sharry/store/H2BlobLengthTest.scala
@@ -6,12 +6,12 @@ import munit.FunSuite
 
 /** Regression test for issues #1327 / #899.
   *
-  * Verifies that the V1.2.2 migration UPDATE correctly recomputes
-  * filemeta.length using OCTET_LENGTH on MEDIUMBLOB chunk_data in H2
-  * PostgreSQL mode (where LENGTH() returns UTF-8 char count, not bytes).
+  * Verifies that the V1.2.2 migration UPDATE correctly recomputes filemeta.length using
+  * OCTET_LENGTH on MEDIUMBLOB chunk_data in H2 PostgreSQL mode (where LENGTH() returns
+  * UTF-8 char count, not bytes).
   *
-  * Also confirms that OCTET_LENGTH on MEDIUMBLOB returns byte count,
-  * which is the precondition for removing the ALTER TABLE from V1.2.2.
+  * Also confirms that OCTET_LENGTH on MEDIUMBLOB returns byte count, which is the
+  * precondition for removing the ALTER TABLE from V1.2.2.
   */
 class H2BlobLengthTest extends FunSuite {
 

--- a/modules/store/src/test/scala/sharry/store/H2BlobLengthTest.scala
+++ b/modules/store/src/test/scala/sharry/store/H2BlobLengthTest.scala
@@ -1,0 +1,112 @@
+package sharry.store
+
+import java.sql.{Connection, DriverManager}
+
+import munit.FunSuite
+
+/** Regression test for issues #1327 / #899.
+  *
+  * Verifies that the V1.2.2 migration UPDATE correctly recomputes
+  * filemeta.length using OCTET_LENGTH on MEDIUMBLOB chunk_data in H2
+  * PostgreSQL mode (where LENGTH() returns UTF-8 char count, not bytes).
+  *
+  * Also confirms that OCTET_LENGTH on MEDIUMBLOB returns byte count,
+  * which is the precondition for removing the ALTER TABLE from V1.2.2.
+  */
+class H2BlobLengthTest extends FunSuite {
+
+  // Post-V1.2.1 schema for the two tables touched by V1.2.2.
+  private val createFilemeta =
+    """CREATE TABLE "filemeta" (
+      |  "file_id"   varchar(254) not null primary key,
+      |  "mimetype"  varchar(254) not null,
+      |  "length"    bigint not null,
+      |  "checksum"  varchar(254) not null,
+      |  "created"   timestamp not null
+      |)""".stripMargin
+
+  private val createFilechunk =
+    """CREATE TABLE "filechunk" (
+      |  "file_id"   varchar(254) not null,
+      |  "chunk_nr"  int not null,
+      |  "chunk_len" int not null,
+      |  "chunk_data" MEDIUMBLOB not null,
+      |  primary key ("file_id", "chunk_nr")
+      |)""".stripMargin
+
+  // The V1.2.2 UPDATE statement (copied verbatim).
+  private val v122Update =
+    """UPDATE "filemeta"
+      |SET "length" = (
+      |  SELECT SUM(OCTET_LENGTH(fc."chunk_data"))
+      |  FROM "filechunk" fc
+      |  WHERE fc."file_id" = "filemeta"."file_id"
+      |)
+      |WHERE EXISTS (
+      |  SELECT 1 FROM "filechunk" fc2 WHERE fc2."file_id" = "filemeta"."file_id"
+      |)""".stripMargin
+
+  private def withConn[A](dbName: String)(f: Connection => A): A = {
+    val url =
+      s"jdbc:h2:mem:$dbName;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1"
+    val conn = DriverManager.getConnection(url, "sa", "")
+    try f(conn)
+    finally conn.close()
+  }
+
+  test("OCTET_LENGTH on MEDIUMBLOB returns byte count") {
+    withConn("octet_length_check") { conn =>
+      val st = conn.createStatement()
+      st.execute("CREATE TABLE t (data MEDIUMBLOB NOT NULL)")
+      // X'C3A9' = UTF-8 for 'é': 2 bytes, 1 code point
+      st.execute("INSERT INTO t VALUES (X'C3A9')")
+      val rs = st.executeQuery("SELECT OCTET_LENGTH(data) FROM t")
+      rs.next()
+      assertEquals(rs.getLong(1), 2L)
+    }
+  }
+
+  test("V1.2.2 UPDATE recomputes filemeta.length from chunk bytes") {
+    withConn("migration_v122") { conn =>
+      val st = conn.createStatement()
+      st.execute(createFilemeta)
+      st.execute(createFilechunk)
+
+      // Seed: file with two chunks — 2 bytes + 3 bytes = 5 bytes total.
+      // filemeta.length is intentionally wrong (1) to simulate the bug.
+      st.execute(
+        """INSERT INTO "filemeta" VALUES
+          |  ('file-1', 'application/octet-stream', 1, 'checksum-1', CURRENT_TIMESTAMP)
+          |""".stripMargin
+      )
+      // X'C3A9' = 2 bytes; X'FFFFFF' = 3 bytes
+      st.execute(
+        """INSERT INTO "filechunk" VALUES
+          |  ('file-1', 0, 2, X'C3A9'),
+          |  ('file-1', 1, 3, X'FFFFFF')
+          |""".stripMargin
+      )
+
+      // Seed: file with no chunks — length must not be touched.
+      st.execute(
+        """INSERT INTO "filemeta" VALUES
+          |  ('file-2', 'text/plain', 99, 'checksum-2', CURRENT_TIMESTAMP)
+          |""".stripMargin
+      )
+
+      st.execute(v122Update)
+
+      val rs = st.executeQuery(
+        """SELECT "file_id", "length" FROM "filemeta" ORDER BY "file_id""""
+      )
+
+      rs.next()
+      assertEquals(rs.getString(1), "file-1")
+      assertEquals(rs.getLong(2), 5L, "file-1 length must equal sum of chunk bytes")
+
+      rs.next()
+      assertEquals(rs.getString(1), "file-2")
+      assertEquals(rs.getLong(2), 99L, "file-2 (no chunks) must not be modified")
+    }
+  }
+}


### PR DESCRIPTION
This PR handles #1327 and #899 

Fix "The file is incomplete" badge shown after successful upload on H2 database

Here is the analysis I did to understand the problem and propose a fix

## Root cause

In 2020, `V1.0.1__fix_blob_type.sql` changed `filechunk.chunkdata` from `bytea` to `MEDIUMBLOB` on H2

> Update bitpeace, change blob type for h2
> The `bytea` type from postgres doesn't work nice with h2, even in
> postgresql compatibility mode. When calculating the checksum of a
> file, using `bytea` resulted in loading everything into memory. Using
> type `blob` simply works as expected.

commit 877f707

H2 in postgresql compatibility mode returns the UTF-8 character count, not the byte count, when LENGTH() is applied to BLOB/MEDIUMBLOB columns

The bug manifests through this chain on every completed TUS upload:
1. TUS POST (createEmptyFile): filemeta.length is set to the advertised Upload-Length header value (correct)
2. TUS PATCH intermediate chunks: InsertChunkResult.Incomplete, no metadata written
3. TUS PATCH last chunk: InsertChunkResult.Complete triggers FileStore.addChunk -> computeSync() -> binny reads the total stored size from H2 using LENGTH(chunk_data) on the MEDIUMBLOB column -> returns character count instead of byte count
4. insertMeta() -> RFileMeta.upsert() overwrites filemeta.length with the underreported value
5. Upload ends: realSize (actual bytes) > filemeta.length (underreported)

The Elm frontend computes storedSize / size and shows "The file is incomplete (106%)"

## Proposed changes and why

The original OOM concern from V1.0.1 no longer applies. Sharry migrated from bitpeace to binny in V1.2.0 (Nov 2021). Binny processes file chunks as a stream (512K at a time, bounded by chunk-size config) and never loads the full file into memory. Memory usage is bounded by chunk size regardless of column type.

**NOTE: H2 LENGTH() remains broken on VARBINARY in postgresql compatibility mode. The column type change is semantically appropriate for raw binary data but does not fix the LENGTH() issue. The real fix is at the Scala level.**

- **Migration V1.2.2**: fixes existing data and reverts chunk_data to VARBINARY(1000000000) and recomputes filemeta.length for all existing files using OCTET_LENGTH(), which always returns bytes
- **RFileMeta.updateLength()**: new Scala method that updates filemeta.length directly from the Scala computed byte count,
  bypassing H2 broken LENGTH() entirely
- **OShare.storeChunk()**: After all TUS chunks are stored (sequential evalMap -> compile.last), filemeta.length is updated in the same transaction as real_size. This call runs after FileStore.addChunk() (including its insertMeta upsert) has completed for all chunks, guaranteeing filemeta.length == real_size at the end of every upload. The background SHA-256 computation (computeAttributes.submit) only updates the checksum column and does not touch length

