### PR TITLE
Add auto publish option for shares after upload

### DIFF
--- a/modules/microsite/docs/doc/configure.md
+++ b/modules/microsite/docs/doc/configure.md
@@ -160,6 +160,27 @@ The following steps must be done manually:
 Then add the above setting into your config file. Test files can be
 found [here](https://www.eicar.org/?page_id=3950).
 
+### Auto-Publish
+
+The `auto-publish-enabled` webapp setting controls whether users can
+opt-in to having their shares automatically published after all files
+are uploaded.
+
+```
+sharry.restserver.webapp {
+  # When enabled, shares are automatically published after all files
+  # are uploaded. Users can toggle this preference in their Settings
+  # page. If disabled, the feature is hidden entirely.
+  auto-publish-enabled = false
+}
+```
+
+When set to `true`, newly created accounts default to auto-publish
+enabled. Users can disable it per-browser in their *Settings* page.
+The preference is stored in `localStorage` under the key
+`sharry-auto-publish`.
+
+
 ### ZIP Download
 
 The `zip-max-size` setting controls whether users can download files

--- a/modules/microsite/docs/doc/webapp.md
+++ b/modules/microsite/docs/doc/webapp.md
@@ -175,6 +175,22 @@ If you rather like to publish it to a new URL, click the black publish
 button at the bottom of the *Detail* pane (see the screenshot below).
 
 
+## Auto-Publish
+
+If the administrator has enabled auto-publish
+(`webapp.auto-publish-enabled = true` in the server configuration),
+shares are automatically published as soon as all files have finished
+uploading — without requiring a manual *Publish* click.
+
+Users can change this preference in their *Settings* page. The toggle
+is only visible when the feature is enabled by the administrator. The
+preference is stored in the browser's local storage, so it persists
+across sessions on the same device but is independent for each browser.
+
+When auto-publish is active, the share's expiry time starts counting
+from the moment the upload completes (same as manual publish).
+
+
 ## Edit Details
 
 The share properties can be changed in the detail view of a share. The

--- a/modules/restapi/src/main/resources/sharry-openapi.yml
+++ b/modules/restapi/src/main/resources/sharry-openapi.yml
@@ -2034,6 +2034,7 @@ components:
         - proxyOnly
         - hideLoginForm
         - zipMaxSize
+        - autoPublishEnabled
       properties:
         appName:
           type: string
@@ -2119,6 +2120,8 @@ components:
             Priority order: user preference (stored in browser) > browser
             auto-detect > this server default > UTC.
             If absent or empty, UTC is used (preserving previous behavior).
+        autoPublishEnabled:
+          type: boolean
     OAuthItem:
       description: |
         Information about a configured OAuth provider.

--- a/modules/restserver/src/main/resources/reference.conf
+++ b/modules/restserver/src/main/resources/reference.conf
@@ -137,6 +137,12 @@ sharry.restserver {
     # Overridden by browser auto-detect and user preference.
     # If not set, UTC is used (preserving current behavior).
     # default-timezone = ""
+
+    # When enabled, shares are automatically published after all files
+    # are uploaded, without requiring the user to click the Publish
+    # button. Users can override this preference in their Settings page.
+    # If set to false, the feature is hidden entirely.
+    auto-publish-enabled = false
   }
 
   backend {

--- a/modules/restserver/src/main/scala/sharry/restserver/config/Config.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/config/Config.scala
@@ -97,7 +97,8 @@ object Config {
       initialTheme: String,
       oauthAutoRedirect: Boolean,
       customHead: String,
-      defaultTimezone: Option[String]
+      defaultTimezone: Option[String],
+      autoPublishEnabled: Boolean
   )
 
   final case class Api(

--- a/modules/restserver/src/main/scala/sharry/restserver/config/ConfigValues.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/config/ConfigValues.scala
@@ -120,6 +120,8 @@ object ConfigValues extends ConfigDecoders:
       key("webapp.oauth-auto-redirect", "WEBAPP_OAUTH_AUTO_REDIRECT").as[Boolean]
     val customHead = key("webapp.custom-head", "WEBAPP_CUSTOM_HEAD")
     val defaultTimezone = key("webapp.default-timezone", "WEBAPP_DEFAULT_TIMEZONE").option
+    val autoPublishEnabled =
+      key("webapp.auto-publish-enabled", "WEBAPP_AUTO_PUBLISH_ENABLED").as[Boolean]
     (
       name,
       icon,
@@ -138,7 +140,8 @@ object ConfigValues extends ConfigDecoders:
       initialTheme,
       oauthRedirect,
       customHead,
-      defaultTimezone
+      defaultTimezone,
+      autoPublishEnabled
     ).mapN(Config.Webapp.apply)
   }
 

--- a/modules/restserver/src/main/scala/sharry/restserver/routes/InfoRoutes.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/routes/InfoRoutes.scala
@@ -81,7 +81,8 @@ object InfoRoutes {
       cfg.backend.auth.isProxyAuthOnly,
       cfg.backend.auth.isAutoLogin,
       cfg.backend.share.zipMaxSize,
-      cfg.webapp.defaultTimezone.filter(_.nonEmpty)
+      cfg.webapp.defaultTimezone.filter(_.nonEmpty),
+      cfg.webapp.autoPublishEnabled
     )
   }
 

--- a/modules/restserver/src/main/templates/index.html
+++ b/modules/restserver/src/main/templates/index.html
@@ -31,11 +31,18 @@
              })();
          var storedTimezone = localStorage.getItem('timezone');
          var account = storedAccount ? JSON.parse(storedAccount) : null;
+         var autoPublish = (function() {
+             var stored = localStorage.getItem('sharry-auto-publish');
+             if (stored === 'true') return true;
+             if (stored === 'false') return false;
+             return null;
+         })();
          var elmFlags = {
              "account": account,
              "language": lang,
              "uiTheme": theme,
              "timezone": storedTimezone,
+             "autoPublish": autoPublish,
              "config": sharryFlags
          };
         </script>

--- a/modules/webapp/src/main/elm/Data/Flags.elm
+++ b/modules/webapp/src/main/elm/Data/Flags.elm
@@ -14,6 +14,7 @@ type alias Flags =
     , language : Maybe String
     , uiTheme : Maybe String
     , timezone : Maybe String
+    , autoPublish : Maybe Bool
     , config : AppConfig
     }
 

--- a/modules/webapp/src/main/elm/Messages/SettingsPage.elm
+++ b/modules/webapp/src/main/elm/Messages/SettingsPage.elm
@@ -216,4 +216,7 @@ br =
     , timezoneManualLabel = "Fuso horário atual:"
     , timezoneResetButton = "Restaurar automático"
     , timezoneInputPlaceholder = "Ex. America/Sao_Paulo"
+    , autoPublishHeader = "Publicação Automática"
+    , autoPublishLabel = "Publicar automaticamente após o envio"
+    , autoPublishInfo = "Se ativado, os compartilhamentos são publicados automaticamente após o envio de todos os arquivos."
     }

--- a/modules/webapp/src/main/elm/Messages/SettingsPage.elm
+++ b/modules/webapp/src/main/elm/Messages/SettingsPage.elm
@@ -27,6 +27,9 @@ type alias Texts =
     , timezoneManualLabel : String
     , timezoneResetButton : String
     , timezoneInputPlaceholder : String
+    , autoPublishHeader : String
+    , autoPublishLabel : String
+    , autoPublishInfo : String
     }
 
 it : Texts
@@ -47,6 +50,9 @@ it =
     , timezoneManualLabel = "Fuso orario attuale:"
     , timezoneResetButton = "Ripristina automatico"
     , timezoneInputPlaceholder = "Es. Europe/Rome"
+    , autoPublishHeader = "Pubblicazione Automatica"
+    , autoPublishLabel = "Pubblica automaticamente dopo il caricamento"
+    , autoPublishInfo = "Se attivo, le condivisioni vengono pubblicate automaticamente al termine del caricamento dei file."
     }
 
 es : Texts
@@ -67,6 +73,9 @@ es =
     , timezoneManualLabel = "Zona horaria actual:"
     , timezoneResetButton = "Restablecer automático"
     , timezoneInputPlaceholder = "Ej. Europe/Madrid"
+    , autoPublishHeader = "Publicación Automática"
+    , autoPublishLabel = "Publicar automáticamente tras la subida"
+    , autoPublishInfo = "Si está activo, los archivos compartidos se publican automáticamente cuando termina la subida."
     }
 
 
@@ -88,6 +97,9 @@ gb =
     , timezoneManualLabel = "Current timezone:"
     , timezoneResetButton = "Reset to automatic"
     , timezoneInputPlaceholder = "E.g. Europe/London"
+    , autoPublishHeader = "Auto-Publish"
+    , autoPublishLabel = "Automatically publish after upload"
+    , autoPublishInfo = "When enabled, shares are automatically published once all files have been uploaded."
     }
 
 
@@ -109,6 +121,9 @@ de =
     , timezoneManualLabel = "Aktuelle Zeitzone:"
     , timezoneResetButton = "Auf automatisch zurücksetzen"
     , timezoneInputPlaceholder = "Z.B. Europe/Berlin"
+    , autoPublishHeader = "Automatisch Veröffentlichen"
+    , autoPublishLabel = "Nach dem Hochladen automatisch veröffentlichen"
+    , autoPublishInfo = "Wenn aktiviert, werden Shares nach dem Hochladen aller Dateien automatisch veröffentlicht."
     }
 
 fr : Texts
@@ -129,6 +144,9 @@ fr =
     , timezoneManualLabel = "Fuseau horaire actuel :"
     , timezoneResetButton = "Revenir à l'automatique"
     , timezoneInputPlaceholder = "Ex. Europe/Paris"
+    , autoPublishHeader = "Publication Automatique"
+    , autoPublishLabel = "Publier automatiquement après l'envoi"
+    , autoPublishInfo = "Si activé, les partages sont publiés automatiquement une fois tous les fichiers envoyés."
     }
 
 
@@ -150,6 +168,9 @@ ja =
     , timezoneManualLabel = "現在のタイムゾーン："
     , timezoneResetButton = "自動に戻す"
     , timezoneInputPlaceholder = "例: Asia/Tokyo"
+    , autoPublishHeader = "自動公開"
+    , autoPublishLabel = "アップロード後に自動的に公開する"
+    , autoPublishInfo = "有効にすると、すべてのファイルがアップロードされた後、共有が自動的に公開されます。"
     }
 
 
@@ -171,4 +192,7 @@ cz =
     , timezoneManualLabel = "Aktuální časové pásmo:"
     , timezoneResetButton = "Obnovit automatické"
     , timezoneInputPlaceholder = "Např. Europe/Prague"
+    , autoPublishHeader = "Automatické Zveřejnění"
+    , autoPublishLabel = "Automaticky zveřejnit po nahrání"
+    , autoPublishInfo = "Pokud je aktivní, sdílení jsou automaticky zveřejněna po nahrání všech souborů."
     }

--- a/modules/webapp/src/main/elm/Page/Settings/Data.elm
+++ b/modules/webapp/src/main/elm/Page/Settings/Data.elm
@@ -30,6 +30,8 @@ type alias Model =
     , banner : Maybe Banner
     , passwordAvailable : Maybe Bool
     , timezoneDropdown : Comp.Dropdown.Model String
+    , autoPublish : Bool
+    , autoPublishEnabled : Bool
     }
 
 
@@ -46,6 +48,8 @@ emptyModel =
     , banner = Nothing
     , passwordAvailable = Nothing
     , timezoneDropdown = Comp.Dropdown.makeSingle
+    , autoPublish = False
+    , autoPublishEnabled = False
     }
 
 
@@ -61,3 +65,4 @@ type Msg
     | SaveResp (Result Http.Error BasicResult)
     | CheckPassResp (Result Http.Error BasicResult)
     | TimezoneDropdownMsg (Comp.Dropdown.Msg String)
+    | ToggleAutoPublish

--- a/modules/webapp/src/main/elm/Page/Settings/Update.elm
+++ b/modules/webapp/src/main/elm/Page/Settings/Update.elm
@@ -7,6 +7,7 @@ import Comp.PasswordInput
 import Data.Flags exposing (Flags)
 import Dict
 import Page.Settings.Data exposing (Banner, Model, Msg(..))
+import Ports
 import TimeZone
 import Util.Http
 import Util.Maybe
@@ -25,8 +26,16 @@ update flags msg model =
                         { options = allZones
                         , selected = flags.timezone
                         }
+
+                resolvedAutoPublish =
+                    Maybe.withDefault flags.config.autoPublishEnabled flags.autoPublish
             in
-            ( { model | banner = Nothing, timezoneDropdown = dropdownModel }
+            ( { model
+                | banner = Nothing
+                , timezoneDropdown = dropdownModel
+                , autoPublish = resolvedAutoPublish
+                , autoPublishEnabled = flags.config.autoPublishEnabled
+              }
             , Cmd.batch
                 [ Api.getEmail flags GetEmailResp
                 , Api.checkPassword flags CheckPassResp
@@ -167,3 +176,10 @@ update flags msg model =
                     Comp.Dropdown.update lm model.timezoneDropdown
             in
             ( { model | timezoneDropdown = dm }, Cmd.none )
+
+        ToggleAutoPublish ->
+            let
+                newVal =
+                    not model.autoPublish
+            in
+            ( { model | autoPublish = newVal }, Ports.setAutoPublish newVal )

--- a/modules/webapp/src/main/elm/Page/Settings/View.elm
+++ b/modules/webapp/src/main/elm/Page/Settings/View.elm
@@ -27,6 +27,7 @@ view texts currentTimezone model =
         , timezoneForm texts currentTimezone model
         , emailForm texts model
         , changePasswordForm texts model
+        , autoPublishForm texts model
         ]
 
 
@@ -171,4 +172,28 @@ banner model =
         [ Maybe.map .text model.banner
             |> Maybe.withDefault ""
             |> text
+        ]
+
+
+autoPublishForm : Texts -> Model -> Html Msg
+autoPublishForm texts model =
+    div
+        [ classList [ ( "hidden", not model.autoPublishEnabled ) ]
+        , class "flex flex-col mt-4"
+        ]
+        [ h2 [ class S.header2 ]
+            [ text texts.autoPublishHeader
+            ]
+        , div [ class "mb-2" ]
+            [ MB.viewItem <|
+                MB.Checkbox
+                    { id = "auto-publish"
+                    , value = model.autoPublish
+                    , tagger = \_ -> ToggleAutoPublish
+                    , label = texts.autoPublishLabel
+                    }
+            , span [ class "text-sm opacity-70 ml-1" ]
+                [ text texts.autoPublishInfo
+                ]
+            ]
         ]

--- a/modules/webapp/src/main/elm/Page/Share/Data.elm
+++ b/modules/webapp/src/main/elm/Page/Share/Data.elm
@@ -32,6 +32,7 @@ type alias Model =
     , uploading : Bool
     , shareId : Maybe String
     , uploadPaused : Bool
+    , autoPublish : Bool
     }
 
 
@@ -52,6 +53,9 @@ emptyModel flags =
     , uploading = False
     , shareId = Nothing
     , uploadPaused = False
+    , autoPublish =
+        flags.config.autoPublishEnabled
+            && Maybe.withDefault True flags.autoPublish
     }
 
 
@@ -69,6 +73,7 @@ type Msg
     | StartStopUpload
     | UploadStopped (Maybe String)
     | ResetForm
+    | AutoPublishResp (Result Http.Error BasicResult)
 
 
 makeProps : Model -> ShareProperties

--- a/modules/webapp/src/main/elm/Page/Share/Update.elm
+++ b/modules/webapp/src/main/elm/Page/Share/Update.elm
@@ -2,6 +2,7 @@ module Page.Share.Update exposing (update)
 
 import Api
 import Api.Model.BasicResult exposing (BasicResult)
+import Api.Model.PublishData exposing (PublishData)
 import Comp.Dropzone2
 import Comp.IntField
 import Comp.MarkdownInput
@@ -113,7 +114,11 @@ update flags msg model =
 
                 submit =
                     if native == [] then
-                        Cmd.none
+                        if model.autoPublish then
+                            Api.publishShare flags idres.id (PublishData False) AutoPublishResp
+
+                        else
+                            Cmd.none
 
                     else
                         UploadData uploadUrl idres.id native Nothing
@@ -138,7 +143,7 @@ update flags msg model =
 
         Uploading state ->
             if Just state.id == model.shareId then
-                trackUpload model state
+                trackUpload flags model state
 
             else
                 ( model, Cmd.none )
@@ -177,9 +182,12 @@ update flags msg model =
         ResetForm ->
             ( Page.Share.Data.emptyModel flags, Cmd.none )
 
+        AutoPublishResp _ ->
+            ( model, Cmd.none )
 
-trackUpload : Model -> UploadState -> ( Model, Cmd Msg )
-trackUpload model state =
+
+trackUpload : Flags -> Model -> UploadState -> ( Model, Cmd Msg )
+trackUpload flags model state =
     let
         next =
             Data.UploadDict.trackUpload model.uploads state
@@ -191,11 +199,30 @@ trackUpload model state =
 
                 _ ->
                     model.formState
+
+        updatedModel =
+            { model
+                | uploads = next
+                , uploadPaused = False
+                , formState = infoMsg
+            }
+
+        ( succ, err ) =
+            Data.UploadDict.countDone next
+
+        allUploadsDone =
+            succ + err == List.length next.selectedFiles
+
+        publishCmd =
+            if allUploadsDone && err == 0 && model.autoPublish then
+                case model.shareId of
+                    Just id ->
+                        Api.publishShare flags id (PublishData False) AutoPublishResp
+
+                    Nothing ->
+                        Cmd.none
+
+            else
+                Cmd.none
     in
-    ( { model
-        | uploads = next
-        , uploadPaused = False
-        , formState = infoMsg
-      }
-    , Cmd.none
-    )
+    ( updatedModel, publishCmd )

--- a/modules/webapp/src/main/elm/Ports.elm
+++ b/modules/webapp/src/main/elm/Ports.elm
@@ -74,3 +74,6 @@ port setTimezone : Maybe String -> Cmd msg
 
 
 port receiveTimezone : (Maybe String -> msg) -> Sub msg
+
+
+port setAutoPublish : Bool -> Cmd msg

--- a/modules/webapp/src/main/webjar/sharry.js
+++ b/modules/webapp/src/main/webjar/sharry.js
@@ -198,5 +198,9 @@ elmApp.ports.setTimezone.subscribe(function(id) {
     }
 });
 
+elmApp.ports.setAutoPublish.subscribe(function(value) {
+    localStorage.setItem("sharry-auto-publish", value ? "true" : "false");
+});
+
 
 applyUiTheme(theme);


### PR DESCRIPTION
This PR handle #1618. 

When `sharry.restserver.webapp.auto-publish-enabled = true`, users can opt in (via their Settings page) to have a share published automatically once all files have uploaded successfully, without needing to click the "Publish" button.

- Admin enables the feature server-wide via `webapp.auto-publish-enabled` (default `false`); when disabled, the setting is hidden entirely from the UI
- Users choose their own preference on the Settings page. it is persisted in the browser (`localStorage`), independent of the account
- Once all selected files finish uploading with zero errors, the share is published automatically
- If any upload ends in an error, auto publish is skipped and the share is left as a draft for review

### Changes:
- `Config.Webapp` / `ConfigValues`: new `autoPublishEnabled: Boolean` flag (`webapp.auto-publish-enabled`)
- `InfoRoutes` / `AppConfig`: `autoPublishEnabled` exposed via `GET /api/v2/open/info/appconfig`
- `index.html`: reads the `sharry-auto-publish` preference from `localStorage` and passes it to Elm as a flag
- Elm `Ports` / `sharry.js`: new `setAutoPublish` port persists the user's preference to `localStorage`
- `Page.Settings`: new toggle to opt in/out, shown only when the server flag is enabled
- `Page.Share`: after upload completion with no errors, calls `Api.publishShare` automatically when the user's preference is on
- Documentation updated in `reference.conf`, `configure.md`, `webapp.md`, and `sharry-openapi.yml`