### PR TITLE
Enforce share password on public download endpoints

### DIFF
--- a/modules/backend/src/main/scala/sharry/backend/share/OShare.scala
+++ b/modules/backend/src/main/scala/sharry/backend/share/OShare.scala
@@ -109,12 +109,13 @@ trait OShare[F[_]] {
       file: Ident,
       pass: Option[Password],
       range: ByteRange
-  ): OptionT[F, FileRange[F]]
+  ): OptionT[F, ShareResult[FileRange[F]]]
 
   def loadZip(
       id: ShareId,
+      pass: Option[Password],
       fileIds: Option[Seq[Ident]] = None
-  ): OptionT[F, Stream[F, Byte]]
+  ): OptionT[F, ShareResult[Stream[F, Byte]]]
 
   def deleteFile(accId: AccountId, file: Ident): OptionT[F, Unit]
 
@@ -393,7 +394,8 @@ object OShare {
           file: Ident,
           pass: Option[Password],
           range: ByteRange
-      ): OptionT[F, FileRange[F]] = {
+      ): OptionT[F, ShareResult[FileRange[F]]] = {
+        // outer Option: row exists; inner: the share password (None if private)
         val checkQuery = shareId.fold(
           pub => Queries.checkFilePublish(pub.id, file),
           priv =>
@@ -403,25 +405,36 @@ object OShare {
         )
 
         for {
-          _ <- OptionT(store.transact(checkQuery))
-          file <- ByteResult.load(store)(file, range)
-        } yield file
+          sharePw <- OptionT(store.transact(checkQuery))
+          result <- checkPassword(shareId, pass, sharePw) match {
+            case ShareResult.Success(_) =>
+              ByteResult
+                .load(store)(file, range)
+                .map(fr => ShareResult.Success(fr): ShareResult[FileRange[F]])
+            case ShareResult.PasswordMismatch =>
+              OptionT.pure[F](ShareResult.PasswordMismatch: ShareResult[FileRange[F]])
+            case ShareResult.PasswordMissing =>
+              OptionT.pure[F](ShareResult.PasswordMissing: ShareResult[FileRange[F]])
+          }
+        } yield result
       }
 
       def loadZip(
           id: ShareId,
+          pass: Option[Password],
           fileIds: Option[Seq[Ident]] = None
-      ): OptionT[F, Stream[F, Byte]] = {
+      ): OptionT[F, ShareResult[Stream[F, Byte]]] = {
         val limit = cfg.zipMaxSize.bytes
         for {
           _ <- OptionT.fromOption[F](Option.when(limit > 0)(()))
           sd <- OptionT(store.transact(Queries.shareDetail(id).value))
+          pwResult = checkPassword(id, pass, sd.share.password)
           selectedFiles = fileIds
             .map(ids => sd.files.filter(f => ids.contains(f.id)))
             .getOrElse(sd.files)
           totalSize = selectedFiles.map(_.length.bytes).sum
           _ <- OptionT.fromOption[F](Option.when(totalSize <= limit)(()))
-        } yield {
+        } yield pwResult.map { _ =>
           val chunkSize = cfg.chunkSize.bytes.toInt
           fsio.readOutputStream[F](chunkSize) { os =>
             val zos = new java.util.zip.ZipOutputStream(os)

--- a/modules/restserver/src/main/scala/sharry/restserver/routes/ByteResponse.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/routes/ByteResponse.scala
@@ -46,12 +46,18 @@ object ByteResponse {
     import dsl._
 
     val rangeDef = makeBinnyByteRange(sr, chunkSize)
+    val authChallenge = `WWW-Authenticate`(Challenge("sharry", "sharry"))
     (for {
-      file <- backend.share.loadFile(shareId, fid, pass, rangeDef)
+      result <- backend.share.loadFile(shareId, fid, pass, rangeDef)
       resp <- OptionT.liftF {
-        if (rangeInvalid(file.fileMeta, sr)) RangeNotSatisfiable()
-        else if (file.fileMeta.length <= chunkSize) allBytes(dsl, req, file)
-        else partialResponse(dsl, req, file, chunkSize, sr)
+        result.fold(
+          file =>
+            if (rangeInvalid(file.fileMeta, sr)) RangeNotSatisfiable()
+            else if (file.fileMeta.length <= chunkSize) allBytes(dsl, req, file)
+            else partialResponse(dsl, req, file, chunkSize, sr),
+          _ => Forbidden(),
+          _ => Unauthorized(authChallenge)
+        )
       }
     } yield resp).getOrElseF(NotFound())
   }
@@ -66,9 +72,16 @@ object ByteResponse {
   ): F[Response[F]] = {
     import dsl._
 
+    val authChallenge = `WWW-Authenticate`(Challenge("sharry", "sharry"))
     (for {
-      file <- backend.share.loadFile(shareId, fid, pass, ByteRange.All)
-      resp <- OptionT.liftF(allBytes(dsl, req, file))
+      result <- backend.share.loadFile(shareId, fid, pass, ByteRange.All)
+      resp <- OptionT.liftF(
+        result.fold(
+          file => allBytes(dsl, req, file),
+          _ => Forbidden(),
+          _ => Unauthorized(authChallenge)
+        )
+      )
     } yield resp).getOrElseF(NotFound())
   }
 

--- a/modules/restserver/src/main/scala/sharry/restserver/routes/OpenShareRoutes.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/routes/OpenShareRoutes.scala
@@ -37,21 +37,28 @@ object OpenShareRoutes {
         ByteResponse(dsl, req, backend, ShareId.publish(id), pw, chunkSize, fid)
 
       case req @ GET -> Root / Ident(id) / "zip" =>
+        val pw = SharryPassword(req)
         val fileIds = req.uri.query.multiParams
           .getOrElse("file", Nil)
           .flatMap(s => Ident.fromString(s).toOption)
         val fileFilter = Option.when(fileIds.nonEmpty)(fileIds)
+        val authChallenge = `WWW-Authenticate`(Challenge("sharry", "sharry"))
         (for {
-          stream <- backend.share.loadZip(ShareId.publish(id), fileFilter)
+          result <- backend.share.loadZip(ShareId.publish(id), pw, fileFilter)
           resp <- OptionT.liftF(
-            Ok(stream).map(
-              _.withHeaders(
-                `Content-Type`(MediaType.application.zip),
-                `Content-Disposition`(
-                  "attachment",
-                  Map(CIString("filename") -> s"$id.zip")
-                )
-              )
+            result.fold(
+              stream =>
+                Ok(stream).map(
+                  _.withHeaders(
+                    `Content-Type`(MediaType.application.zip),
+                    `Content-Disposition`(
+                      "attachment",
+                      Map(CIString("filename") -> s"$id.zip")
+                    )
+                  )
+                ),
+              _ => Forbidden(),
+              _ => Unauthorized(authChallenge)
             )
           )
         } yield resp).getOrElseF(dsl.NotFound())

--- a/modules/restserver/src/main/scala/sharry/restserver/routes/ShareDetailResponse.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/routes/ShareDetailResponse.scala
@@ -10,6 +10,7 @@ import sharry.common.*
 import sharry.restapi.model.{ShareDetail as ShareDetailDto, *}
 import sharry.restserver.config.Config
 import sharry.restserver.http4s.ClientRequestInfo
+import sharry.restserver.routes.headers.SharryPassword
 
 import org.http4s.*
 import org.http4s.circe.CirceEntityEncoder.*
@@ -39,12 +40,33 @@ object ShareDetailResponse {
 
     val authChallenge = `WWW-Authenticate`(Challenge("sharry", "sharry"))
 
+    // Store the verified password in a cookie scoped to this share, so the
+    // download links (which can't set the header) still pass the check.
+    def withPasswordCookie(resp: Response[F]): Response[F] =
+      (shareId, pass) match {
+        case (ShareId.PublicId(pid), Some(pw)) =>
+          val baseUrl = getBaseUrl(cfg, req)
+          val path = baseUrl.path / "api" / "v2" / "open" / "share" / pid.id
+          resp.addCookie(
+            ResponseCookie(
+              SharryPassword.name,
+              SharryPassword.encodeCookieValue(pw.pass),
+              domain = None,
+              path = Some(path.asString),
+              httpOnly = true,
+              secure = baseUrl.scheme.exists(_.endsWith("s")),
+              sameSite = Some(SameSite.Strict)
+            )
+          )
+        case _ => resp
+      }
+
     (for {
       now <- OptionT.liftF(Timestamp.current[F])
       detail <- backend.share.shareDetails(shareId, pass)
       resp <- OptionT.liftF(
         detail.fold(
-          d => Ok(shareDetail(now, baseUri)(d)),
+          d => Ok(shareDetail(now, baseUri)(d)).map(withPasswordCookie),
           _ =>
             logger
               .info(

--- a/modules/restserver/src/main/scala/sharry/restserver/routes/ShareRoutes.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/routes/ShareRoutes.scala
@@ -106,16 +106,22 @@ object ShareRoutes {
           .flatMap(s => Ident.fromString(s).toOption)
         val fileFilter = Option.when(fileIds.nonEmpty)(fileIds)
         (for {
-          stream <- backend.share.loadZip(ShareId.secured(id, token.account), fileFilter)
+          result <- backend.share
+            .loadZip(ShareId.secured(id, token.account), None, fileFilter)
           resp <- OptionT.liftF(
-            Ok(stream).map(
-              _.withHeaders(
-                `Content-Type`(MediaType.application.zip),
-                `Content-Disposition`(
-                  "attachment",
-                  Map(CIString("filename") -> s"$id.zip")
-                )
-              )
+            result.fold(
+              stream =>
+                Ok(stream).map(
+                  _.withHeaders(
+                    `Content-Type`(MediaType.application.zip),
+                    `Content-Disposition`(
+                      "attachment",
+                      Map(CIString("filename") -> s"$id.zip")
+                    )
+                  )
+                ),
+              _ => Forbidden(),
+              _ => Unauthorized(`WWW-Authenticate`(Challenge("sharry", "sharry")))
             )
           )
         } yield resp).getOrElseF(NotFound())

--- a/modules/restserver/src/main/scala/sharry/restserver/routes/headers/SharryPassword.scala
+++ b/modules/restserver/src/main/scala/sharry/restserver/routes/headers/SharryPassword.scala
@@ -1,5 +1,7 @@
 package sharry.restserver.routes.headers
 
+import java.nio.charset.StandardCharsets
+
 import sharry.common.LenientUri
 import sharry.common.Password
 
@@ -8,10 +10,42 @@ import org.typelevel.ci.CIString
 
 object SharryPassword {
 
+  val name: String = "sharry-password"
+
+  private val headerName = CIString(name)
+
+  private val unreserved: Set[Char] =
+    (('A' to 'Z') ++ ('a' to 'z') ++ ('0' to '9')).toSet ++ Set('-', '_', '.', '~')
+
+  // Encode into unreserved chars only so the value is safe in a cookie.
+  // LenientUri.percentEncode is for URI paths and leaves ';', '"', '\' and
+  // control chars alone, which would break the Set-Cookie header.
+  def encodeCookieValue(value: String): String = {
+    val out = new StringBuilder
+    value.getBytes(StandardCharsets.UTF_8).foreach { b =>
+      val c = (b & 0xff).toChar
+      if (unreserved.contains(c)) out.append(c)
+      else out.append("%%%02X".format(b & 0xff))
+    }
+    out.toString
+  }
+
+  // Header for the webapp's XHR calls, cookie for plain browser downloads
+  // that can't set a header.
   def apply[F[_]](req: Request[F]): Option[Password] =
+    fromHeader(req).orElse(fromCookie(req))
+
+  private def fromHeader[F[_]](req: Request[F]): Option[Password] =
     req.headers
-      .get(CIString("sharry-password"))
+      .get(headerName)
       .map(_.head.value)
+      .flatMap(LenientUri.percentDecode)
+      .map(Password.apply)
+
+  private def fromCookie[F[_]](req: Request[F]): Option[Password] =
+    req.cookies
+      .find(_.name == name)
+      .map(_.content)
       .flatMap(LenientUri.percentDecode)
       .map(Password.apply)
 

--- a/modules/restserver/src/test/scala/sharry/restserver/routes/headers/SharryPasswordTest.scala
+++ b/modules/restserver/src/test/scala/sharry/restserver/routes/headers/SharryPasswordTest.scala
@@ -1,0 +1,60 @@
+package sharry.restserver.routes.headers
+
+import cats.effect.IO
+
+import munit.*
+import org.http4s.*
+import org.typelevel.ci.CIString
+
+class SharryPasswordTest extends FunSuite {
+
+  private def withHeader(value: String): Request[IO] =
+    Request[IO](headers = Headers(Header.Raw(CIString("Sharry-Password"), value)))
+
+  private def withCookie(value: String): Request[IO] =
+    Request[IO]().addCookie(SharryPassword.name, value)
+
+  test("reads the password from the header") {
+    assertEquals(SharryPassword(withHeader("hunter2")).map(_.pass), Some("hunter2"))
+  }
+
+  test("reads the password from the cookie") {
+    assertEquals(SharryPassword(withCookie("hunter2")).map(_.pass), Some("hunter2"))
+  }
+
+  test("header takes precedence over the cookie") {
+    val req = withHeader("fromHeader").addCookie(SharryPassword.name, "fromCookie")
+    assertEquals(SharryPassword(req).map(_.pass), Some("fromHeader"))
+  }
+
+  test("percent-decodes the header value") {
+    assertEquals(SharryPassword(withHeader("a%20b%26c")).map(_.pass), Some("a b&c"))
+  }
+
+  test("percent-decodes the cookie value") {
+    assertEquals(SharryPassword(withCookie("a%20b%26c")).map(_.pass), Some("a b&c"))
+  }
+
+  test("is empty when neither header nor cookie is present") {
+    assertEquals(SharryPassword(Request[IO]()), None)
+  }
+
+  test("encodeCookieValue round-trips through the cookie read path") {
+    // chars a naive encoder would let break the cookie, plus non-ascii
+    val passwords =
+      List("hunter2", "a b&c", "p;a,s\"s\\word", "=> ;Path=/;", "muenchen €", "%41%42")
+    passwords.foreach { pw =>
+      val encoded = SharryPassword.encodeCookieValue(pw)
+      val req = Request[IO]().addCookie(SharryPassword.name, encoded)
+      assertEquals(SharryPassword(req).map(_.pass), Some(pw), s"failed for: $pw")
+    }
+  }
+
+  test("encodeCookieValue produces a value with no cookie-unsafe characters") {
+    val del = 0x7f.toChar
+    val unsafe = Set(' ', ';', ',', '"', '\\', '\r', '\n', '\t', del)
+    val encoded =
+      SharryPassword.encodeCookieValue("x; Max-Age=999\r\nSet-Cookie: a=b")
+    assert(encoded.forall(c => !unsafe.contains(c) && c >= ' '), encoded)
+  }
+}


### PR DESCRIPTION
## Enforce share password on public download endpoints

### Problem

A password-protected **public** share only had its password checked on the share *detail*
endpoint (`shareDetails` → `checkPassword`). The two endpoints that actually serve content did
not check it:

- **`GET /api/v2/open/share/{id}/zip`** streamed a ZIP of **all** files without ever reading the
  password. Knowing only the public `publishId` (the shared link) was enough to download
  everything.
- **`GET /api/v2/open/share/{id}/file/{fid}`** served an individual file without checking the
  password. `Queries.checkFilePublish` even selected the share's `password` column, but the
  value was discarded (only the outer "row exists" `Option` was evaluated).

This defeats the threat model the password documents in `webapp.md` ("a second secret next to
the URL"), and is more impactful next to the recent `require-share-password` option
(#1777 / #1820): an admin enabling it assumes every share is protected, while `/zip` still
bypasses it.

### Fix

Run the existing `checkPassword` on every public route that serves content, the same way
`shareDetails` already does:

- `OShare.loadZip` now takes the password, loads the share detail, and gates the stream behind
  `checkPassword`, returning `ShareResult`.
- `OShare.loadFile` compares the supplied password against the one `checkFilePublish` returns.
- `OpenShareRoutes` reads the `Sharry-Password` header on `/zip` and, like `ByteResponse`,
  turns the result into **401** (password missing) or **403** (mismatch).

Private (authenticated) routes are unaffected: `checkPassword` short-circuits to success for
`PrivateId`.

### Browser downloads (cookie)

The webapp fetches the share detail over XHR (which can send the `Sharry-Password` header), but
the downloads themselves are plain browser navigations to the zip/file endpoints, which can't
set a custom header. So the header alone would break downloads of a password-protected share.

The password is therefore also accepted from a cookie:

- `SharryPassword` reads the password from the `Sharry-Password` header, or falls back to a
  `sharry-password` cookie.
- After a successful public detail request with a valid password, `ShareDetailResponse` sets an
  `HttpOnly`, `SameSite=Strict` cookie scoped to that share's path (`/api/v2/open/share/{id}`),
  `Secure` when the base URL is https. The browser then sends it on the `/zip` and `/file/{fid}`
  navigations. No webapp change needed.

The cookie value is percent-encoded to the RFC 3986 unreserved set, so passwords containing
`;`, `"`, `\`, etc. can't break or inject into the `Set-Cookie` header.

### Behaviour after the fix

| Request | Before | After |
|---|---|---|
| `/zip` without password (protected share) | 200 + all files | **401** |
| `/zip` with correct password (header or cookie) | 200 | 200 |
| `/file/{fid}` without password (protected share) | 200 + file | **401** |
| `/file/{fid}` with wrong password | 200 + file | **403** |
| public share without a password | 200 | 200 (unchanged) |
| authenticated `/sec/...` routes | 200 | 200 (unchanged) |

### Tests

Added `SharryPasswordTest` (MUnit): header/cookie extraction, header-over-cookie precedence,
percent-decoding, and cookie-value encoding round-trips (including `;`, `"`, `\`, space and
non-ascii). `restserver/test` is green with `-Werror` on.

### Possible follow-ups

- `maxViews` is still not enforced on `/zip` and `/file` (only on the detail endpoint), left
  out to keep this focused on the password bypass; happy to add it.
- Longer term, centralizing the public-access checks (password + validity + maxViews) in one
  place all `/open/share/...` routes go through would stop new download routes from
  reintroducing the gap.
